### PR TITLE
Fix TypeError on "click->player#play" action

### DIFF
--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -67,6 +67,7 @@ export default class extends Controller {
   }
 
   showTrackTitle() {
+    if (this.currentIndex() < 0) return;
     const title = this.trackTargets[this.currentIndex()].querySelector("span").innerText;
     this.trackTitleTarget.classList.remove("invisible");
     this.trackTitleTarget.innerText = title;


### PR DESCRIPTION
I was seeing the following JS exception in my browser in development:

    Error invoking action "click->player#play"
    TypeError: this.trackTargets[this.currentIndex()] is undefined

It seems as if the `showTrackTitle` function was being called when `this.currentIndex()` was `-1`. I think we can safely ignore these calls and so I've added a guard condition to the function.