### PR TITLE
Make Sidekiq web UI available to admin users

### DIFF
--- a/app/constraints/admin_constraint.rb
+++ b/app/constraints/admin_constraint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AdminConstraint
+  class << self
+    def matches?(request)
+      cookies = ActionDispatch::Cookies::CookieJar.build(request, request.cookies)
+      session = Session.find_by(id: cookies.signed[:session_token])
+      session && session.user.present? && session.user.admin?
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
   get  'log_in', to: 'sessions#new'
   post 'log_in', to: 'sessions#create'
@@ -75,4 +77,6 @@ Rails.application.routes.draw do
       )
     end
   end
+
+  mount Sidekiq::Web => '/sidekiq', constraints: AdminConstraint
 end


### PR DESCRIPTION
This means that when an admin user is signed in, they can view the Sidekiq dashboard at `/sidekiq`. I think this could be quite useful for diagnosing problem (and even doing things like killing jobs) while we're in this early development phase of the project.

The authentication/authorization documentation in [this Sidekiq documentation][1] seems to use some outdated Rails mechanism. So I've used an adapted version of the code in [this article][2] instead. However, since I'm not very familiar with the authentication mechanism we're using in this app, I'm not sure what I've done is the simplest solution, although it does work!

[1]: https://github.com/sidekiq/sidekiq/wiki/Monitoring#authentication
[2]: https://mauromorales.com/2022/08/02/rails-routing-advanced-constraints-for-user-authentication-without-devise/