### PR TITLE
Display filename of existing profile picture in artist form

### DIFF
--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -3,7 +3,11 @@
   <%= form.text_field :name, class: 'w-full mb-3' %>
   <%= form.text_field :location, class: 'w-full mb-3' %>
   <%= form.text_field :description, class: 'w-full mb-3' %>
-  <%= form.label :profile_picture %>
+  <% if form.object.profile_picture.attached? %>
+    <%= form.label :profile_picture, "Profile picture (#{form.object.profile_picture.filename})" %>
+  <% else %>
+    <%= form.label :profile_picture, "Profile picture" %>
+  <% end %>
   <%= form.file_field :profile_picture, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-600 hover:file:bg-amber-500 file:text-white' %>
 
   <p class="mb-3">By creating an artist profile on jam.coop and


### PR DESCRIPTION
Unlike in [this commit][1], I've used the built-in `ActionView::Helpers::FormBuilder#label` method rather than the customized `TailwindFormBuilder#labels` method that I used for the file fields in the album form. That's because at the moment there aren't any validation rules on `Artist#profile_picture`, so we don't (yet) need to be able to display validation errors withinin the label.

See #60.

### New artist page
<img width="717" alt="Screenshot 2023-12-22 at 23 00 52" src="https://github.com/freerange/music-coop/assets/3169/7ee8dbf6-63c7-4202-870d-17757dcf704a">


### Edit artist page
<img width="717" alt="Screenshot 2023-12-22 at 23 01 00" src="https://github.com/freerange/music-coop/assets/3169/d61b827b-3d0a-405a-949a-c947a27ead9a">

[1]: https://github.com/freerange/music-coop/commit/3aaec284d7d07355620dd646529ba94bcf2287b8