### PR TITLE
Add AlbumPolicy::Scope & use in ArtistsController#show

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -13,11 +13,7 @@ class ArtistsController < ApplicationController
   def show
     skip_authorization
 
-    @albums = if pundit_user.admin? || pundit_user.artists.include?(@artist)
-                Album.where(artist: @artist)
-              else
-                Album.published.where(artist: @artist)
-              end
+    @albums = policy_scope(@artist.albums)
   end
 
   def new

--- a/app/policies/album_policy.rb
+++ b/app/policies/album_policy.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class AlbumPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user.admin? || scope.map(&:artist).uniq.all? { |a| user.artists.include?(a) }
+        scope.all
+      else
+        scope.published
+      end
+    end
+  end
+
   def show?
     return record.published? unless user.signed_in?
 


### PR DESCRIPTION
I think this is more idiomatic use of Pundit and it simplifies `ArtistsController#show` nicely which will make adding an Atom feed for that action easier.

I suspect there's a nicer way to implement the 2nd expression in the `if` statement in `AlbumPolicy::Scope#resolve`, but the one I've gone with seems to result in a sensible number of queries.