### PR TITLE
Set Sidekiq retries to 3 even for ActionMailer::MailDeliveryJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,6 +6,4 @@ class ApplicationJob < ActiveJob::Base
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   # discard_on ActiveJob::DeserializationError
-
-  sidekiq_options retry: 3
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Sidekiq.default_job_options = { retry: 3 }


### PR DESCRIPTION
`ActionMailer::MailDeliveryJob` [inherits][1] from `ActiveJob::Base`; not from `ApplicationJob`. I suspect that's why the `retry` option in `ApplicationJob` didn't seem to be having any effect on jobs created by sending an email.

It's hard to get a definitive answer, but I'm fairly confident setting the `retry` option on `Sidekiq.default_job_options` should apply globally to all jobs sent to Sidekiq, i.e. including `ActionMailer::MailDeliveryJob`.

Fixes #143 (hopefully!🤞)

[1]: https://github.com/rails/rails/blob/23938052acd773fa24068debe56cd892cbf8d868/actionmailer/lib/action_mailer/mail_delivery_job.rb#L13