### PR TITLE
Published albums must have at least one track

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -27,8 +27,11 @@ class AlbumsController < ApplicationController
   end
 
   def publish
-    @album.publish
-    AlbumMailer.with(album: @album).published.deliver_later
+    if @album.publish
+      AlbumMailer.with(album: @album).published.deliver_later
+    else
+      flash[:alert] = "Errors prohibited this album from being saved: #{@album.errors.full_messages.to_sentence}"
+    end
     redirect_to artist_album_url(@album.artist, @album)
   end
 

--- a/test/factories/album.rb
+++ b/test/factories/album.rb
@@ -28,9 +28,8 @@ FactoryBot.define do
         number_of_tracks { 2 }
       end
 
-      after(:create) do |album, evaluator|
-        create_list(:track, evaluator.number_of_tracks, album:)
-        album.reload
+      after(:build) do |album, evaluator|
+        album.tracks = build_list(:track, evaluator.number_of_tracks, album:)
       end
     end
   end

--- a/test/factories/album.rb
+++ b/test/factories/album.rb
@@ -44,7 +44,7 @@ FactoryBot.define do
     publication_status { :pending }
   end
 
-  factory :published_album, parent: :album do
+  factory :published_album, parent: :album, traits: %i[with_tracks] do
     publication_status { :published }
   end
 end

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -95,7 +95,7 @@ class AlbumTest < ActiveSupport::TestCase
   end
 
   test 'publish enqueues ZipDownloadJob to prepare mp3v0 download' do
-    album = create(:unpublished_album)
+    album = create(:unpublished_album, :with_tracks)
 
     args_matcher = ->(job_args) { job_args[1][:format] == :mp3v0 }
     assert_enqueued_with(job: ZipDownloadJob, args: args_matcher) do
@@ -104,7 +104,7 @@ class AlbumTest < ActiveSupport::TestCase
   end
 
   test 'publish enqueues ZipDownloadJob to prepare flac download' do
-    album = create(:unpublished_album)
+    album = create(:unpublished_album, :with_tracks)
 
     args_matcher = ->(job_args) { job_args[1][:format] == :flac }
     assert_enqueued_with(job: ZipDownloadJob, args: args_matcher) do
@@ -222,5 +222,16 @@ class AlbumTest < ActiveSupport::TestCase
       assert_not album.valid?
       assert_includes album.errors[:released_on], "must be less than or equal to #{Time.zone.today}"
     end
+  end
+
+  test 'is valid if not published and has no tracks' do
+    album = build(:unpublished_album, tracks: [])
+    assert album.valid?
+  end
+
+  test 'is not valid if published and has no tracks' do
+    album = build(:album, tracks: [], publication_status: :published)
+    assert_not album.valid?
+    assert_includes album.errors[:number_of_tracks], 'must be greater than 0'
   end
 end

--- a/test/system/publishing_an_album_test.rb
+++ b/test/system/publishing_an_album_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class PublishingAnAlbumTest < ApplicationSystemTestCase
   setup do
-    @album = create(:unpublished_album)
+    @album = create(:unpublished_album, :with_tracks)
     user = create(:user)
     user.artists << @album.artist
     log_in_as(user)


### PR DESCRIPTION
Publishing an album with no tracks doesn't make much sense and causes exceptions like [this one][1], because the album has no preview to point the audio element at.

We'll also need to unpublish any published albums that have no tracks. These can be found by running `Album.published.select { |a| a.tracks.count == 0 }.map(&:slug)`. Currently there is only [this one](https://jam.coop/artists/clive-murray/albums/love-and-painkillers). I plan to email any affected artists to explain why we've unpublished their album. I contemplated doing the unpublishing in a migration, but since there's only one at the moment, I plan to do it in a Rails console in production.

[1]: https://app.rollbar.com/a/gofreerange/fix/item/jam/49

Fixes https://github.com/freerange/jam-coop/issues/148.