### PR TITLE
Adds a `License` model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.0-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     parallel (1.24.0)
@@ -340,6 +342,8 @@ GEM
     stripe (10.5.0)
     tailwindcss-rails (2.0.32-arm64-darwin)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.32-x86_64-darwin)
+      railties (>= 6.0.0)
     tailwindcss-rails (2.0.32-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.3.0)
@@ -363,6 +367,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class License < ApplicationRecord
+  validates :code, presence: true
+  validates :label, presence: true
+end

--- a/db/migrate/20240208220722_create_licenses.rb
+++ b/db/migrate/20240208220722_create_licenses.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateLicenses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :licenses do |t|
+      t.string :code, null: false
+      t.text :source, null: true
+      t.text :label, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_10_214125) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_08_220722) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,6 +91,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_10_214125) do
     t.string "confirm_token"
     t.datetime "sending_suppressed_at"
     t.index ["email"], name: "index_interests_on_email", unique: true
+  end
+
+  create_table "licenses", force: :cascade do |t|
+    t.string "code", null: false
+    t.text "source"
+    t.text "label", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "password_reset_tokens", force: :cascade do |t|

--- a/test/factories/license.rb
+++ b/test/factories/license.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :license do
+    code { 'by' }
+    label { 'Attribution' }
+  end
+end

--- a/test/models/license_test.rb
+++ b/test/models/license_test.rb
@@ -9,10 +9,11 @@ class LicenseTest < ActiveSupport::TestCase
     assert build(:license).valid?
   end
 
-  test 'is not valid if code is not present' do
+  test 'is not valid if requires attribuets are misising' do
     license = License.new
 
     assert_not license.valid?
-    assert_includes license.errors[:code], 'file cannot be missing'
+    assert_includes license.errors[:code], "can't be blank"
+    assert_includes license.errors[:label], "can't be blank"
   end
 end

--- a/test/models/license_test.rb
+++ b/test/models/license_test.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LicenseTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test 'fixture is valid' do
+    assert build(:license).valid?
+  end
+
+  test 'is not valid if code is not present' do
+    license = License.new
+
+    assert_not license.valid?
+    assert_includes license.errors[:code], 'file cannot be missing'
+  end
+end


### PR DESCRIPTION
This PR part 1 of N to allow Artists to assign a license to an Album. 

Ultimately I felt that a _configuration_ table for the license data was a better option than an enum since it would 1) add a hard relational constraint on the association's data and would consolidate important secondary _metadata_ values like `label` and `source` all in one place. In other words, a License is a richer domain model than something like a the common type of single value enum such as `status`.