### PR TITLE
Ensure Time.zone.today is evaluated at comparison time

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -16,7 +16,7 @@ class Album < ApplicationRecord
 
   validates :title, presence: true
   validates :price, presence: true, numericality: true
-  validates :released_on, comparison: { less_than_or_equal_to: Time.zone.today, allow_blank: true }
+  validates :released_on, comparison: { less_than_or_equal_to: -> { Time.zone.today }, allow_blank: true }
   validates :number_of_tracks, comparison: { greater_than: 0 }, if: :published?
   validates(
     :cover,


### PR DESCRIPTION
Before this commit I think `Time.zone.today` was only being evaluated when the application first booted, rather than each time the validation was called. This manifested as validation error messages for some users when the application hadn't been deployed for several days (e.g. #169).

I'm hopeful that passing a lambda to `less_than_or_equal_to` will fix this but I'm unsure of how to express that in a test.

Fixes: #169 