### PR TITLE
Use FLAC tag names in FLAC metadata

### DIFF
--- a/app/models/transcode_command.rb
+++ b/app/models/transcode_command.rb
@@ -51,7 +51,7 @@ class TranscodeCommand
     supported_keys = @metadata.slice(*tag_keys)
     return if supported_keys.empty?
 
-    entries = supported_keys.map { |k, v| %(-metadata #{id3v23_key_for(k)}="#{v}") }
+    entries = supported_keys.map { |k, v| %(-metadata #{tag_key_for(k)}="#{v}") }
     "-write_id3v2 1 -id3v2_version 3 #{entries.join(' ')}"
   end
 
@@ -72,7 +72,7 @@ class TranscodeCommand
     METADATA_KEYS_VS_ID3V23_TAGS.keys
   end
 
-  def id3v23_key_for(key)
+  def tag_key_for(key)
     METADATA_KEYS_VS_ID3V23_TAGS[key]
   end
 end

--- a/app/models/transcode_command.rb
+++ b/app/models/transcode_command.rb
@@ -23,7 +23,7 @@ class TranscodeCommand
       input_options,
       image_options,
       metadata_options,
-      transcoding_options(@format),
+      transcoding_options,
       @output.path
     ].compact.join(' ')
   end
@@ -55,8 +55,8 @@ class TranscodeCommand
     "-write_id3v2 1 -id3v2_version 3 #{entries.join(' ')}"
   end
 
-  def transcoding_options(format)
-    case format
+  def transcoding_options
+    case @format
     when :mp3v0
       '-codec:a libmp3lame -q:a 0 -f mp3'
     when :mp3128k

--- a/app/models/transcode_command.rb
+++ b/app/models/transcode_command.rb
@@ -48,7 +48,7 @@ class TranscodeCommand
   end
 
   def metadata_options
-    supported_keys = @metadata.slice(*id3v23_keys)
+    supported_keys = @metadata.slice(*tag_keys)
     return if supported_keys.empty?
 
     entries = supported_keys.map { |k, v| %(-metadata #{id3v23_key_for(k)}="#{v}") }
@@ -68,7 +68,7 @@ class TranscodeCommand
     end
   end
 
-  def id3v23_keys
+  def tag_keys
     METADATA_KEYS_VS_ID3V23_TAGS.keys
   end
 

--- a/test/models/transcode_command_test.rb
+++ b/test/models/transcode_command_test.rb
@@ -58,6 +58,20 @@ class TranscodeCommandTest < ActiveSupport::TestCase
     assert_contains_pair(command_string, ['-metadata', 'TPE1="artist-name"'])
   end
 
+  test 'adds metadata tags for FLAC format' do
+    metadata = {
+      track_title: 'track-title',
+      track_number: 'track-number',
+      album_title: 'album-title',
+      artist_name: 'artist-name'
+    }
+    command_string = TranscodeCommand.new(@input, @output, :flac, metadata).generate
+    assert_contains_pair(command_string, ['-metadata', 'TITLE="track-title"'])
+    assert_contains_pair(command_string, ['-metadata', 'TRACKNUMBER="track-number"'])
+    assert_contains_pair(command_string, ['-metadata', 'ALBUM="album-title"'])
+    assert_contains_pair(command_string, ['-metadata', 'ARTIST="artist-name"'])
+  end
+
   test 'transcodes audio to mp3 using libmp3lame codec highest audio quality' do
     command_string = TranscodeCommand.new(@input, @output, :mp3v0).generate
     assert_contains_pair(command_string, ['-codec:a', 'libmp3lame'])

--- a/test/models/transcode_command_test.rb
+++ b/test/models/transcode_command_test.rb
@@ -42,7 +42,7 @@ class TranscodeCommandTest < ActiveSupport::TestCase
     assert_contains_pair(command_string, ['-c', 'copy'])
   end
 
-  test 'adds metadata using ID3v2.3 format' do
+  test 'adds metadata tags using ID3v2.3 format for MP3 formats' do
     metadata = {
       track_title: 'track-title',
       track_number: 'track-number',


### PR DESCRIPTION
In #183 @graue pointed out that FLAC has its own tag names ([FLAC FAQ](https://xiph.org/flac/faq.html#general__tagging); [Vorbis comment docs](https://xiph.org/vorbis/doc/v-comment.html)). This changes the ffmpeg transcoding for FLAC tracks to use those names. However, it's unclear to me whether we also need to change the encoding of the metadata - currently I've left the `-write_id3v2 1` & `-id3v2_version 3` ffmpeg options in place on the basis that @graue is already able to view the tags on a FLAC track; it was just that the tag names were incorrect.

An initial search of the internet suggests that it might be better to use [the `metaflac` tool](https://xiph.org/flac/documentation_tools_metaflac.html) to add metadata to a track, but that would be a moderately significant change and it would probably be worth changing MP3 tagging to work in a similar way, i.e. with a specialist command line tool rather than just using ffmpeg.

Fixes #183.
