### PR TITLE
Extract card component and improve card styling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'stripe', '~> 10.5'
 gem 'tailwindcss-rails'
 gem 'turbo-rails'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem 'view_component'
 gem 'zaru', '~> 1.0'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,6 +201,7 @@ GEM
     matrix (0.4.2)
     meta-tags (2.19.0)
       actionpack (>= 3.2.0, < 7.2)
+    method_source (1.1.0)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.22.2)
@@ -373,6 +374,10 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
+    view_component (3.13.0)
+      activesupport (>= 5.2.0, < 8.0)
+      concurrent-ruby (~> 1.0)
+      method_source (~> 1.0)
     webmock (3.23.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -437,6 +442,7 @@ DEPENDENCIES
   tailwindcss-rails
   turbo-rails
   tzinfo-data
+  view_component
   webmock
   zaru (~> 1.0)
 

--- a/app/components/card_component.rb
+++ b/app/components/card_component.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CardComponent < ViewComponent::Base
+  def initialize(title:, subtitle:, image:)
+    @title = title
+    @subtitle = subtitle
+    @image = image
+
+    super
+  end
+end

--- a/app/components/card_component/card_component.html.erb
+++ b/app/components/card_component/card_component.html.erb
@@ -1,5 +1,5 @@
-<div>
-  <div class="border border-slate-200 aspect-w-1 aspect-h-1">
+<div class="group">
+  <div class="border border-slate-200 aspect-w-1 aspect-h-1 group-hover:shadow">
     <%= image_tag @image, class: 'object-cover' %>
   </div>
   <p class='font-medium text-slate-600 break-words'><%= @title %></p>

--- a/app/components/card_component/card_component.html.erb
+++ b/app/components/card_component/card_component.html.erb
@@ -1,0 +1,7 @@
+<div class="max-w-md">
+  <div class="border border-slate-200 aspect-w-1 aspect-h-1">
+    <%= image_tag @image, class: 'object-cover' %>
+  </div>
+  <p class='text-sm text-slate-500 break-words'><%= @title %></p>
+  <p class='text-sm text-slate-400 break-words'><%= @subtitle %></p>
+</div>

--- a/app/components/card_component/card_component.html.erb
+++ b/app/components/card_component/card_component.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-md">
+<div>
   <div class="border border-slate-200 aspect-w-1 aspect-h-1">
     <%= image_tag @image, class: 'object-cover' %>
   </div>

--- a/app/components/card_component/card_component.html.erb
+++ b/app/components/card_component/card_component.html.erb
@@ -2,6 +2,6 @@
   <div class="border border-slate-200 aspect-w-1 aspect-h-1">
     <%= image_tag @image, class: 'object-cover' %>
   </div>
-  <p class='text-sm text-slate-500 break-words'><%= @title %></p>
-  <p class='text-sm text-slate-400 break-words'><%= @subtitle %></p>
+  <p class='font-medium text-slate-600 break-words'><%= @title %></p>
+  <p class='text-slate-600 break-words'><%= @subtitle %></p>
 </div>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -27,18 +27,11 @@
 <div class="pt-4 grid grid-cols-3 gap-4">
   <% @albums.in_release_order.each do |album| %>
     <%= link_to(artist_album_path(album.artist, album)) do %>
-    <div>
-      <div class="border border-slate-200 aspect-w-1 aspect-h-1">
-        <% if album.cover.representable? %>
-        <%= image_tag cdn_url(album.cover.representation(resize_to_limit: [1000, 1000])), class: 'object-cover' %>
-        <% end %>
-      </div>
-      <% if album.published? %>
-      <p class='text-sm text-slate-500 break-words'><%= album.title %></p>
-      <% else %>
-      <p class='text-sm text-slate-500 break-words'><%= album.title %> (<%= album.publication_status %>)</p>
-      <% end %>
-    </div>
+      <%= render(CardComponent.new(
+        title: album.title,
+        subtitle: ( album.publication_status if !album.published? ),
+        image: ( cdn_url(album.cover.representation(resize_to_limit: [1000, 1000])) if album.cover.representable? )
+      )) %>
     <% end %>
   <% end %>
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -7,15 +7,11 @@
 <div class="pt-4 grid grid-cols-3 gap-4">
   <% Current.user.collection.each do |purchase| %>
     <%= link_to(artist_album_path(purchase.album.artist, purchase.album)) do %>
-    <div>
-      <div class="border border-slate-200 aspect-w-1 aspect-h-1">
-        <% if purchase.album.cover.representable? %>
-        <%= image_tag cdn_url(purchase.album.cover.representation(resize_to_limit: [1000, 1000])), class: 'object-cover' %>
-        <% end %>
-      </div>
-      <p class='text-sm text-slate-500 break-words'><%= purchase.album.title %></p>
-      <p class='text-sm text-slate-400 break-words'><%= purchase.album.artist.name %></p>
-    </div>
+      <%= render(CardComponent.new(
+        title: purchase.album.title,
+        subtitle: purchase.album.artist.name,
+        image: ( cdn_url(purchase.album.cover.representation(resize_to_limit: [1000, 1000])) if purchase.album.cover.representable? )
+      )) %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/interests/new.html.erb
+++ b/app/views/interests/new.html.erb
@@ -14,17 +14,13 @@
   <h2 class="text-slate-400 mb-3 uppercase">Recently purchased</h2>
   <div class="grid grid-cols-4 gap-4 mb-3">
     <% Album.best_selling.limit(8).each do |album| %>
-    <%= link_to(artist_album_path(album.artist, album)) do %>
-    <div>
-      <div class="border border-slate-200 aspect-w-1 aspect-h-1">
-        <% if album.cover.representable? %>
-        <%= image_tag cdn_url(album.cover.representation(resize_to_limit: [1000, 1000])), class: 'object-cover' %>
-        <% end %>
-      </div>
-      <p class='text-sm text-slate-500 break-words'><%= album.title %></p>
-      <p class='text-sm text-slate-400 break-words'><%= album.artist.name %></p>
-    </div>
-    <% end %>
+      <%= link_to(artist_album_path(album.artist, album)) do %>
+        <%= render(CardComponent.new(
+          title: album.title,
+          subtitle: album.artist.name,
+          image: ( cdn_url(album.cover.representation(resize_to_limit: [1000, 1000])) if album.cover.representable? )
+        )) %>
+      <% end %>
     <% end %>
   </div>
   <div class="flex justify-end">

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js',
     './app/views/**/*.{erb,haml,html,slim}',
+    './app/components/**/*.{erb,haml,html,slim}',
     './app/form_builders/*.rb',
     './lib/renderers/*.rb'
   ],

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
     './app/javascript/**/*.js',
     './app/views/**/*.{erb,haml,html,slim}',
     './app/components/**/*.{erb,haml,html,slim}',
+    './test/components/previews/**/*.{erb,haml,html,slim}',
     './app/form_builders/*.rb',
     './lib/renderers/*.rb'
   ],

--- a/test/components/card_component_test.rb
+++ b/test/components/card_component_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CardComponentTest < ViewComponent::TestCase
+  def setup
+    render_inline(
+      CardComponent.new(
+        title: 'Title',
+        subtitle: 'Subtitle',
+        image: 'http://example.com'
+      )
+    )
+  end
+
+  def test_component_renders_title
+    assert_text('Title')
+  end
+
+  def test_component_renders_subtitle
+    assert_text('Subtitle')
+  end
+
+  def test_component_renders_image
+    assert_selector("img[src='http://example.com']")
+  end
+end

--- a/test/components/previews/card_component_preview.rb
+++ b/test/components/previews/card_component_preview.rb
@@ -1,13 +1,5 @@
 # frozen_string_literal: true
 
 class CardComponentPreview < ViewComponent::Preview
-  def default
-    render(
-      CardComponent.new(
-        title: 'Fables of the Reconstuction',
-        subtitle: 'R.E.M.',
-        image: 'https://upload.wikimedia.org/wikipedia/en/d/dc/R.E.M._-_Fables_of_the_Reconstruction.jpg'
-      )
-    )
-  end
+  def default; end
 end

--- a/test/components/previews/card_component_preview.rb
+++ b/test/components/previews/card_component_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CardComponentPreview < ViewComponent::Preview
+  def default
+    render(
+      CardComponent.new(
+        title: 'Fables of the Reconstuction',
+        subtitle: 'R.E.M.',
+        image: 'https://upload.wikimedia.org/wikipedia/en/d/dc/R.E.M._-_Fables_of_the_Reconstruction.jpg'
+      )
+    )
+  end
+end

--- a/test/components/previews/card_component_preview/default.html.erb
+++ b/test/components/previews/card_component_preview/default.html.erb
@@ -1,0 +1,10 @@
+<div class="w-1/4">
+  <%= render(
+    CardComponent.new(
+      title: 'Fables of the Reconstuction',
+      subtitle: 'R.E.M.',
+      image: 'https://upload.wikimedia.org/wikipedia/en/d/dc/R.E.M._-_Fables_of_the_Reconstruction.jpg'
+    )
+  )
+  %>
+</div>

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -57,7 +57,7 @@ class ArtistsControllerTestSignedIn < ActionDispatch::IntegrationTest
 
     get artist_url(@artist)
 
-    assert_select 'p', 'Album Title (unpublished)'
+    assert_select 'p', 'unpublished'
   end
 
   test '#show should include pending albums' do
@@ -65,7 +65,7 @@ class ArtistsControllerTestSignedIn < ActionDispatch::IntegrationTest
 
     get artist_url(@artist)
 
-    assert_select 'p', 'Album Title (pending)'
+    assert_select 'p', 'pending'
   end
 
   test '#new' do
@@ -130,7 +130,7 @@ class ArtistsControllerTestSignedInArtist < ActionDispatch::IntegrationTest
 
     get artist_url(@artist)
 
-    assert_select 'p', 'Album Title (unpublished)'
+    assert_select 'p', 'unpublished'
   end
 
   test '#show should include pending albums' do
@@ -138,7 +138,7 @@ class ArtistsControllerTestSignedInArtist < ActionDispatch::IntegrationTest
 
     get artist_url(@artist)
 
-    assert_select 'p', 'Album Title (pending)'
+    assert_select 'p', 'pending'
   end
 end
 
@@ -202,7 +202,7 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
 
     get artist_url(@artist)
 
-    assert_select 'p', { text: 'Album Title (unpublished)', count: 0 }
+    assert_select 'p', { text: 'unpublished', count: 0 }
   end
 
   test '#show should not include pending albums' do
@@ -210,7 +210,7 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
 
     get artist_url(@artist)
 
-    assert_select 'p', { text: 'Album Title (pending)', count: 0 }
+    assert_select 'p', { text: 'pending', count: 0 }
   end
 
   test '#show includes auto-discovery link for atom feed' do

--- a/test/system/creating_an_album_test.rb
+++ b/test/system/creating_an_album_test.rb
@@ -24,8 +24,9 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
 
     click_on 'Save'
 
-    assert_text "A Hard Day's Night (unpublished)"
-    click_on "A Hard Day's Night (unpublished)"
+    assert_text "A Hard Day's Night"
+    assert_text 'unpublished'
+    click_on "A Hard Day's Night"
     assert_text '1. And I Love Her'
   end
 

--- a/test/system/publishing_an_album_test.rb
+++ b/test/system/publishing_an_album_test.rb
@@ -13,7 +13,7 @@ class PublishingAnAlbumTest < ApplicationSystemTestCase
   test 'publishing an album' do
     # Artist requests publication
     visit artist_url(@album.artist)
-    click_on "#{@album.title} (unpublished)"
+    click_on @album.title.to_s
     click_on 'Publish'
     assert_text "Thank you! We'll email you when your album is published."
     sign_out


### PR DESCRIPTION
In his [design review](https://www.figma.com/design/8H4p74Qcv6NlHU34LLWjRn/Jam.Coop?node-id=69-2086&t=ohMpx6PRMGiYQQpa-0) Chad suggested increasing the size and weight of the album card text and adding a light shadow as a hover state. 

This PR makes those changes by first extracting a ViewComponent for the card and then applying the changes in a single place.  

## Old 
<img width="219" alt="Screenshot 2024-08-09 at 15 36 27" src="https://github.com/user-attachments/assets/9ef15c21-6410-4af4-8cb5-1ec8493eae40">

## New
<img width="219" alt="Screenshot 2024-08-09 at 15 36 12" src="https://github.com/user-attachments/assets/0cc2360f-79b7-4ab3-b657-1cd6f9fd5a47">
