### PR TITLE
Embedded player for social media

### DIFF
--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TracksController < ApplicationController
-  before_action :set_track, only: %i[move_higher move_lower]
+  before_action :set_track, only: %i[move_higher move_lower player]
 
   def move_higher
     authorize @track
@@ -17,6 +17,12 @@ class TracksController < ApplicationController
     @track.move_lower
 
     redirect_to artist_album_path(@track.artist, @track.album)
+  end
+
+  def player
+    authorize @track
+    @album = @track.album
+    render layout: false
   end
 
   private

--- a/app/policies/track_policy.rb
+++ b/app/policies/track_policy.rb
@@ -12,4 +12,8 @@ class TrackPolicy < ApplicationPolicy
   def reorder?
     record.unpublished? && move_lower? && move_higher?
   end
+
+  def player?
+    true
+  end
 end

--- a/app/views/tracks/player.html.erb
+++ b/app/views/tracks/player.html.erb
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= display_meta_tags site: "jam.coop" %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
+    <%= hotwire_livereload_tags if Rails.env.development? %>
+  </head>
+
+  <style>
+    .player {
+      width: 100vw;
+      height: 100vh;
+      background-image: url('<%= cdn_url(@album.cover.representation(resize_to_limit: [750, 750])) %>');
+      background-size: cover;
+      background-position: 50% 50%;
+    }
+
+    .footer {
+      position: absolute;
+      right: 0;
+      bottom: 3%;
+      left: 3%;
+     }
+  </style>
+
+  <body>
+    <div class="player">
+      <div class="footer">
+        <span class="text-white bg-slate-600 px-2 py-1">
+          <%= text_link_to @album.title, artist_album_url(@album.artist, @album) %> by <%= @album.artist.name %>
+        </span>
+        <span></span>
+      </div>
+    </div>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     member do
       post 'move_higher'
       post 'move_lower'
+      get 'player'
     end
   end
 


### PR DESCRIPTION
@chrislo I started doing some work on this a while ago based on how SoundCloud does it.

If you look at the `<head>` on [this album page](https://soundcloud.com/brenvik/brenvik-jogging-house), you can see the following which is used by the hellsite and/or other social media:

```html
<meta
  property="twitter:player"
  content="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F780253879&amp;auto_play=false&amp;show_artwork=true&amp;visual=true&amp;origin=twitter"
>
```

Also there are also these oEmbed links which I believe is what Mastodon uses:
```html
<link
  rel="alternate"
  type="text/xml+oembed"
  href="https://soundcloud.com/oembed?url=https%3A%2F%2Fsoundcloud.com%2Fbrenvik%2Fbrenvik-jogging-house&amp;format=xml"
>
<link
  rel="alternate"
  type="text/json+oembed"
  href="https://soundcloud.com/oembed?url=https%3A%2F%2Fsoundcloud.com%2Fbrenvik%2Fbrenvik-jogging-house&amp;format=json"
>
```

These oEmbed endpoints serve up:

#### XML
```xml
<oembed>
  <version type="float">1.0</version>
  <type>rich</type>
  <provider-name>SoundCloud</provider-name>
  <provider-url>https://soundcloud.com</provider-url>
  <height type="integer">400</height>
  <width>100%</width>
  <title>BRENVIK - Jogging House by Brenvik</title>
  <description>
    Composing & mixing : @brenvik Mastering : @cadillacprod Instagram : @brenvikmusic Facebook : facebook.com Brenvikofficial
  </description>
  <thumbnail-url>
    https://i1.sndcdn.com/artworks-8vNJgn1vdOH333WX-hQm7AQ-t500x500.jpg
  </thumbnail-url>
  <html>
    <![CDATA[<iframe width="100%" height="400" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F780253879&show_artwork=true"></iframe>]]>
  </html>
  <author-name>Brenvik</author-name>
  <author-url>https://soundcloud.com/brenvik</author-url>
</oembed>
```

#### JSON
```json
{
  "version": 1,
  "type": "rich",
  "provider_name": "SoundCloud",
  "provider_url": "https://soundcloud.com",
  "height": 400,
  "width": "100%",
  "title": "BRENVIK - Jogging House by Brenvik",
  "description": "Composing & mixing : @brenvik\nMastering : @cadillacprod\n\nInstagram : @brenvikmusic\nFacebook : facebook.com/Brenvikofficial",
  "thumbnail_url": "https://i1.sndcdn.com/artworks-8vNJgn1vdOH333WX-hQm7AQ-t500x500.jpg",
  "html": "<iframe width=\"100%\" height=\"400\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F780253879&show_artwork=true\"></iframe>",
  "author_name": "Brenvik",
  "author_url": "https://soundcloud.com/brenvik"
}
```

But the common theme of all three is the "player URL" which looks like [this](
https://w.soundcloud.com/player/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F780253879&show_artwork=true). It's the latter that I think I was trying to build in this WIP branch...