### PR TITLE
Add release date to track metadata

### DIFF
--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -27,12 +27,15 @@ class Track < ApplicationRecord
   end
 
   def metadata
-    {
+    data = {
       track_title: title,
       track_number: number,
       album_title: album.title,
       artist_name: artist.name
     }
+
+    data[:release_date] = album.released_on if album.released_on
+    data
   end
 
   def transcode

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -34,7 +34,7 @@ class Track < ApplicationRecord
       artist_name: artist.name
     }
 
-    data[:release_date] = album.released_on if album.released_on
+    data[:release_year] = album.released_on.year if album.released_on
     data
   end
 

--- a/app/models/transcode_command.rb
+++ b/app/models/transcode_command.rb
@@ -6,7 +6,7 @@ class TranscodeCommand
     track_number: 'TRCK',
     album_title: 'TALB',
     artist_name: 'TPE1',
-    release_date: 'DATE'
+    release_year: 'TORY'
   }.freeze
 
   METADATA_KEYS_VS_FLAC_TAGS = {
@@ -14,7 +14,7 @@ class TranscodeCommand
     track_number: 'TRACKNUMBER',
     album_title: 'ALBUM',
     artist_name: 'ARTIST',
-    release_date: 'DATE'
+    release_year: 'DATE'
   }.freeze
 
   def initialize(input, output, format, metadata = {}, image = nil)

--- a/app/models/transcode_command.rb
+++ b/app/models/transcode_command.rb
@@ -5,14 +5,16 @@ class TranscodeCommand
     track_title: 'TIT2',
     track_number: 'TRCK',
     album_title: 'TALB',
-    artist_name: 'TPE1'
+    artist_name: 'TPE1',
+    release_date: 'DATE'
   }.freeze
 
   METADATA_KEYS_VS_FLAC_TAGS = {
     track_title: 'TITLE',
     track_number: 'TRACKNUMBER',
     album_title: 'ALBUM',
-    artist_name: 'ARTIST'
+    artist_name: 'ARTIST',
+    release_date: 'DATE'
   }.freeze
 
   def initialize(input, output, format, metadata = {}, image = nil)

--- a/test/jobs/transcode_job_test.rb
+++ b/test/jobs/transcode_job_test.rb
@@ -53,7 +53,7 @@ class TranscodeJobTest < ActiveJob::TestCase
   end
 
   test 'it adds metadata to the generated MP3 file' do
-    album = create(:album, released_on: Time.zone.today)
+    album = create(:album, released_on: Date.parse('2024-10-03'))
     track = create(:track, album:)
     TranscodeJob.perform_now(track)
 
@@ -66,12 +66,12 @@ class TranscodeJobTest < ActiveJob::TestCase
       assert_equal '01', metadata['format']['tags']['track']
       assert_equal album.title, metadata['format']['tags']['album']
       assert_equal album.artist.name, metadata['format']['tags']['artist']
-      assert_equal album.released_on.to_s, metadata['format']['tags']['date']
+      assert_equal '2024', metadata['format']['tags']['TORY']
     end
   end
 
   test 'it adds metadata to the generated flac file' do
-    album = create(:album, released_on: Time.zone.today)
+    album = create(:album, released_on: Date.parse('2024-10-03'))
     track = create(:track, album:)
     TranscodeJob.perform_now(track, format: :flac)
 
@@ -84,7 +84,7 @@ class TranscodeJobTest < ActiveJob::TestCase
       assert_equal '01', metadata['format']['tags']['track']
       assert_equal album.title, metadata['format']['tags']['ALBUM']
       assert_equal album.artist.name, metadata['format']['tags']['ARTIST']
-      assert_equal album.released_on.to_s, metadata['format']['tags']['DATE']
+      assert_equal '2024', metadata['format']['tags']['DATE']
     end
   end
 end

--- a/test/jobs/transcode_job_test.rb
+++ b/test/jobs/transcode_job_test.rb
@@ -51,4 +51,40 @@ class TranscodeJobTest < ActiveJob::TestCase
 
     TranscodeJob.perform_now(build(:track))
   end
+
+  test 'it adds metadata to the generated MP3 file' do
+    album = create(:album, released_on: Time.zone.today)
+    track = create(:track, album:)
+    TranscodeJob.perform_now(track)
+
+    track.transcodes.mp3v0.first.file.open do |file|
+      cmd = "ffprobe -i #{file.path} -v quiet -print_format json -show_format"
+      std_out, _status = Open3.capture2(cmd)
+      metadata = JSON.parse(std_out)
+
+      assert_equal track.title, metadata['format']['tags']['title']
+      assert_equal '01', metadata['format']['tags']['track']
+      assert_equal album.title, metadata['format']['tags']['album']
+      assert_equal album.artist.name, metadata['format']['tags']['artist']
+      assert_equal album.released_on.to_s, metadata['format']['tags']['date']
+    end
+  end
+
+  test 'it adds metadata to the generated flac file' do
+    album = create(:album, released_on: Time.zone.today)
+    track = create(:track, album:)
+    TranscodeJob.perform_now(track, format: :flac)
+
+    track.transcodes.flac.first.file.open do |file|
+      cmd = "ffprobe -i #{file.path} -v quiet -print_format json -show_format"
+      std_out, _status = Open3.capture2(cmd)
+      metadata = JSON.parse(std_out)
+
+      assert_equal track.title, metadata['format']['tags']['TITLE']
+      assert_equal '01', metadata['format']['tags']['track']
+      assert_equal album.title, metadata['format']['tags']['ALBUM']
+      assert_equal album.artist.name, metadata['format']['tags']['ARTIST']
+      assert_equal album.released_on.to_s, metadata['format']['tags']['DATE']
+    end
+  end
 end

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -112,7 +112,7 @@ class TrackTest < ActiveSupport::TestCase
 
     metadata = track.metadata
 
-    assert_equal track.album.released_on, metadata[:release_date]
+    assert_equal track.album.released_on.year, metadata[:release_year]
   end
 
   test '#number' do

--- a/test/models/track_test.rb
+++ b/test/models/track_test.rb
@@ -103,6 +103,16 @@ class TrackTest < ActiveSupport::TestCase
     assert_equal track.number, metadata[:track_number]
     assert_equal track.album.title, metadata[:album_title]
     assert_equal track.album.artist.name, metadata[:artist_name]
+    assert_not metadata.key?(:release_date)
+  end
+
+  test '#metadata when album has released_on' do
+    album = create(:album, released_on: Time.zone.today)
+    track = create(:track, album:)
+
+    metadata = track.metadata
+
+    assert_equal track.album.released_on, metadata[:release_date]
   end
 
   test '#number' do

--- a/test/models/transcode_command_test.rb
+++ b/test/models/transcode_command_test.rb
@@ -48,7 +48,7 @@ class TranscodeCommandTest < ActiveSupport::TestCase
       track_number: 'track-number',
       album_title: 'album-title',
       artist_name: 'artist-name',
-      release_date: 'release-date'
+      release_year: 'release-year'
     }
     command_string = TranscodeCommand.new(@input, @output, :mp3v0, metadata).generate
     assert_contains_pair(command_string, ['-write_id3v2', '1'])
@@ -57,7 +57,7 @@ class TranscodeCommandTest < ActiveSupport::TestCase
     assert_contains_pair(command_string, ['-metadata', 'TRCK="track-number"'])
     assert_contains_pair(command_string, ['-metadata', 'TALB="album-title"'])
     assert_contains_pair(command_string, ['-metadata', 'TPE1="artist-name"'])
-    assert_contains_pair(command_string, ['-metadata', 'DATE="release-date"'])
+    assert_contains_pair(command_string, ['-metadata', 'TORY="release-year"'])
   end
 
   test 'adds metadata tags for FLAC format' do
@@ -66,14 +66,14 @@ class TranscodeCommandTest < ActiveSupport::TestCase
       track_number: 'track-number',
       album_title: 'album-title',
       artist_name: 'artist-name',
-      release_date: 'release-date'
+      release_year: 'release-year'
     }
     command_string = TranscodeCommand.new(@input, @output, :flac, metadata).generate
     assert_contains_pair(command_string, ['-metadata', 'TITLE="track-title"'])
     assert_contains_pair(command_string, ['-metadata', 'TRACKNUMBER="track-number"'])
     assert_contains_pair(command_string, ['-metadata', 'ALBUM="album-title"'])
     assert_contains_pair(command_string, ['-metadata', 'ARTIST="artist-name"'])
-    assert_contains_pair(command_string, ['-metadata', 'DATE="release-date"'])
+    assert_contains_pair(command_string, ['-metadata', 'DATE="release-year"'])
   end
 
   test 'transcodes audio to mp3 using libmp3lame codec highest audio quality' do

--- a/test/models/transcode_command_test.rb
+++ b/test/models/transcode_command_test.rb
@@ -47,7 +47,8 @@ class TranscodeCommandTest < ActiveSupport::TestCase
       track_title: 'track-title',
       track_number: 'track-number',
       album_title: 'album-title',
-      artist_name: 'artist-name'
+      artist_name: 'artist-name',
+      release_date: 'release-date'
     }
     command_string = TranscodeCommand.new(@input, @output, :mp3v0, metadata).generate
     assert_contains_pair(command_string, ['-write_id3v2', '1'])
@@ -56,6 +57,7 @@ class TranscodeCommandTest < ActiveSupport::TestCase
     assert_contains_pair(command_string, ['-metadata', 'TRCK="track-number"'])
     assert_contains_pair(command_string, ['-metadata', 'TALB="album-title"'])
     assert_contains_pair(command_string, ['-metadata', 'TPE1="artist-name"'])
+    assert_contains_pair(command_string, ['-metadata', 'DATE="release-date"'])
   end
 
   test 'adds metadata tags for FLAC format' do
@@ -63,13 +65,15 @@ class TranscodeCommandTest < ActiveSupport::TestCase
       track_title: 'track-title',
       track_number: 'track-number',
       album_title: 'album-title',
-      artist_name: 'artist-name'
+      artist_name: 'artist-name',
+      release_date: 'release-date'
     }
     command_string = TranscodeCommand.new(@input, @output, :flac, metadata).generate
     assert_contains_pair(command_string, ['-metadata', 'TITLE="track-title"'])
     assert_contains_pair(command_string, ['-metadata', 'TRACKNUMBER="track-number"'])
     assert_contains_pair(command_string, ['-metadata', 'ALBUM="album-title"'])
     assert_contains_pair(command_string, ['-metadata', 'ARTIST="artist-name"'])
+    assert_contains_pair(command_string, ['-metadata', 'DATE="release-date"'])
   end
 
   test 'transcodes audio to mp3 using libmp3lame codec highest audio quality' do


### PR DESCRIPTION
This PR reworks #222 to get it ready to merge. 

@lenikadali - thanks so much for your hard work on this! I've made a couple of small changes:

- I squashed your commits together and added a bit of explanation in the commit message to document what you and @floehopper discussed about metadata field names
- I added a more "end to end" test that extracts the metadata using `ffprobe` to make it a bit easier for us to change the metadata fields in the future and have some confidence that `ffmpeg` is doing the right thing. 