### PR TITLE
Model copyright/licenses

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -65,7 +65,8 @@ class AlbumsController < ApplicationController
   def album_params
     params
       .require(:album)
-      .permit(:title, :price, :cover, :about, :credits, :released_on, tracks_attributes: %i[id title original _destroy])
+      .permit(:title, :price, :cover, :about, :credits, :released_on, :license_id,
+              tracks_attributes: %i[id title original _destroy])
   end
 
   def authorize_album

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -11,6 +11,7 @@ class Album < ApplicationRecord
   has_many :downloads, dependent: :destroy
   has_many :purchases, dependent: :destroy
   has_one_attached :cover
+  belongs_to :license
 
   accepts_nested_attributes_for :tracks, reject_if: :all_blank, allow_destroy: true
 

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class License < ApplicationRecord
+  validates :code, presence: true
+  validates :label, presence: true
+end

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -6,6 +6,7 @@
     <%= form.text_area :about, rows: 10, class: 'w-full mb-3' %>
     <%= form.text_area :credits, rows: 10, class: 'w-full mb-3' %>
     <%= form.date_field :released_on, max: Time.zone.today, class: 'w-full mb-3' %>
+    <%= form.select :license_id, License.all.pluck(:label, :id), selected: album.license_id, class: 'w-full mb-3' %>
   <% end %>
   <%= render(SidebarSectionComponent.new(title: 'Cover')) do |component| %>
     <% component.with_subtitle do %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -130,18 +130,24 @@
       </section>
     <% end %>
 
-    <% if @album.released_on %>
-      <section class="mb-6">
-        <p>released <%= @album.released_on.strftime('%B %-d, %Y') %></p>
-      </section>
-    <% end %>
-
     <% if @album.credits %>
       <section>
         <%= format_metadata(@album.credits) %>
       </section>
     <% end %>
   </div>
+
+  <section class="mt-6">
+    <% if @album.released_on %>
+      <p><strong>Released:</strong> <%= @album.released_on.strftime('%B %-d, %Y') %></p>
+    <% end %>
+
+    <% if @album.license.source %>
+      <p><strong>License:</strong> <%= link_to @album.license.label, @album.license.source, class: 'underline' %></p>
+    <% else %>
+      <p><strong>License:</strong> <%= @album.license.label %></p>
+    <% end %>
+  </section>
 
   <% content_for :admin do %>
     <div>

--- a/db/migrate/20240208220722_create_licenses.rb
+++ b/db/migrate/20240208220722_create_licenses.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateLicenses < ActiveRecord::Migration[7.1]
+  def change
+    create_table :licenses do |t|
+      t.string :code, null: false
+      t.text :source, null: true
+      t.text :label, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250207140601_add_belongs_to_license_relationship_to_album.rb
+++ b/db/migrate/20250207140601_add_belongs_to_license_relationship_to_album.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddBelongsToLicenseRelationshipToAlbum < ActiveRecord::Migration[7.2]
+  class License < ApplicationRecord; end
+
+  def change
+    add_reference :albums, :license, foreign_key: true
+
+    default_license = License.find_or_create_by(code: 'all_rights_reserved', source: nil, label: 'All Rights Reserved')
+    Album.find_each do |album|
+      album.update(license_id: default_license.id)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_18_202726) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_140601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -54,7 +54,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_18_202726) do
     t.date "released_on"
     t.integer "publication_status", default: 0, null: false
     t.date "first_published_on"
+    t.bigint "license_id"
     t.index ["artist_id"], name: "index_albums_on_artist_id"
+    t.index ["license_id"], name: "index_albums_on_license_id"
     t.index ["slug", "artist_id"], name: "index_albums_on_slug_and_artist_id", unique: true
   end
 
@@ -173,6 +175,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_18_202726) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "albums", "artists"
+  add_foreign_key "albums", "licenses"
   add_foreign_key "artists", "users"
   add_foreign_key "downloads", "albums"
   add_foreign_key "email_verification_tokens", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,6 +93,14 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_18_202726) do
     t.index ["email"], name: "index_interests_on_email", unique: true
   end
 
+  create_table "licenses", force: :cascade do |t|
+    t.string "code", null: false
+    t.text "source"
+    t.text "label", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "password_reset_tokens", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_password_reset_tokens_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,21 @@
 # frozen_string_literal: true
 
+[
+  { code: 'all_rights_reserved', source: nil, label: 'All Rights Reserved' },
+  { code: 'by', source: 'https://creativecommons.org/licenses/by/4.0/', label: 'Attribution' },
+  { code: 'by_sa', source: 'https://creativecommons.org/licenses/by-sa/4.0/',
+    label: 'Attribution-ShareAlike 4.0 International' },
+  { code: 'by_nc', source: 'https://creativecommons.org/licenses/by-nc/4.0/',
+    label: 'Attribution-NonCommercial' },
+  { code: 'by_nc_sa', source: 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
+    label: 'Attribution-NonCommercial-ShareAlike' },
+  { code: 'by_nd', source: 'https://creativecommons.org/licenses/by-nd/4.0/',
+    label: 'Attribution-NoDerivs' },
+  { code: 'by_nc_nd', source: 'https://creativecommons.org/licenses/by-nc-nd/4.0/',
+    label: 'Attribution-NonCommercial-NoDerivs' },
+  { code: 'cc_0', source: 'https://creativecommons.org/publicdomain/zero/1.0/', label: 'No Copyright' }
+].each do |data|
+  License.find_or_create_by(code: data[:code], source: data[:source], label: data[:label])
+end
+
 load(Rails.root.join('db/seeds/development.rb')) if Rails.env.development?

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -23,6 +23,7 @@ User.create!(email: 'fan@example.com', password: 'fan-jam-coop', verified: true)
       title: Faker::Music.album,
       about: Faker::Lorem.paragraph,
       credits: Faker::Lorem.paragraph,
+      license: License.find_by(code: 'all_rights_reserved'),
       artist:
     )
     album.cover.attach(

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -75,7 +75,7 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
   test '#create' do
     assert_difference('Album.count') do
       post artist_albums_url(@album.artist), params: {
-        album: { title: 'Example', cover: fixture_file_upload('cover.png') }
+        album: { title: 'Example', cover: fixture_file_upload('cover.png'), license_id: License.first.id }
       }
     end
 
@@ -87,6 +87,7 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
       post artist_albums_url(@album.artist), params: {
         album: { title: 'Example',
                  cover: fixture_file_upload('cover.png'),
+                 license_id: License.first.id,
                  tracks_attributes: { '0': { title: 'Test', original: fixture_file_upload('one.wav') } } }
       }
     end

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -64,7 +64,7 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
 
     get artist_album_url(@album.artist, @album)
 
-    assert_select 'p', 'released June 20, 2023'
+    assert_select 'p', 'Released: June 20, 2023'
   end
 
   test '#new' do

--- a/test/factories/album.rb
+++ b/test/factories/album.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
     end
     publication_status { :unpublished }
     released_on { Time.zone.today }
+    license
 
     after(:build) do |album|
       album.cover.attach(

--- a/test/factories/license.rb
+++ b/test/factories/license.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :license do
+    code { 'by' }
+    label { 'Attribution' }
+  end
+end

--- a/test/models/license_test.rb
+++ b/test/models/license_test.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LicenseTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
+
+  test 'fixture is valid' do
+    assert build(:license).valid?
+  end
+
+  test 'is not valid if code is not present' do
+    license = License.new
+
+    assert_not license.valid?
+    assert_includes license.errors[:code], "can't be blank"
+  end
+
+  test 'is not valid if label is not present' do
+    license = License.new
+
+    assert_not license.valid?
+    assert_includes license.errors[:label], "can't be blank"
+  end
+end

--- a/test/system/creating_an_album_test.rb
+++ b/test/system/creating_an_album_test.rb
@@ -5,6 +5,7 @@ require 'application_system_test_case'
 class CreatingAnAlbumTest < ApplicationSystemTestCase
   setup do
     @artist = create(:artist)
+    create(:license)
     user = create(:user, artists: [@artist])
 
     log_in_as(user)


### PR DESCRIPTION
Closes #134 
Superseeds #167, #173

This PR adds a License model, an association to Album and a simple UI for applying a license to an album. I've used @rosschapman's work on modelling and then, inspired by #173, updated the UI code to work with the design changes we've made since that PR was opened. 

For now I've made "All rights reserved" the default license for all existing and new Albums. After this PR lands I plan to search through the descriptions of all existing albums and see if I can give them explicit License associations where the artist has indicated they want that license applied. 

Thanks to @rosschapman and @floehopper for their contributions to this feature so far. And to @lenikadali who expressed interest in helping to get it finished in Discord and discussed the approach with me.