### PR TITLE
Fix atom feed for artist with no published albums

### DIFF
--- a/app/views/artists/show.atom.builder
+++ b/app/views/artists/show.atom.builder
@@ -4,7 +4,8 @@ albums = @albums.in_release_order
 
 atom_feed(language: 'en-GB', schema_date: 2024) do |f|
   f.title "#{@artist.name} albums on jam.coop"
-  f.updated albums.first.released_on
+  f.updated albums.first&.released_on || @artist.updated_at
+  f.author { |a| a.name @artist.name }
   albums.each do |album|
     id = "tag:#{request.host},2024:#{artist_album_path(@artist, album)}"
     url = artist_album_url(@artist, album)

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -230,10 +230,22 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
 
     feed = RSS::Parser.parse(response.body)
     assert_equal "#{@artist.name} albums on jam.coop", feed.title.content
+    assert_equal @artist.name, feed.author.name.content
     assert_equal 'Newer', feed.entries.first.title.content
     assert_equal 'Older', feed.entries.last.title.content
     assert_not_includes feed.entries.map(&:title).map(&:content), 'Pending'
     assert_not_includes feed.entries.map(&:title).map(&:content), 'Unpublished'
+  end
+
+  test '#show with atom format for artist with no published albums should render atom feed' do
+    @artist.albums << create(:unpublished_album)
+
+    get artist_url(@artist, format: :atom)
+
+    feed = RSS::Parser.parse(response.body)
+    assert_equal "#{@artist.name} albums on jam.coop", feed.title.content
+    assert_equal @artist.name, feed.author.name.content
+    assert_equal 0, feed.entries.length
   end
 
   test '#new' do


### PR DESCRIPTION
Previously we were seeing exceptions like [this one][1]:

    ActionView::Template::Error: undefined method `released_on' for nil:NilClass

This was because the atom feed was assuming that the artist always had at least one published album, but it seems as if it's possible to view the artist page for such an artist which makes the atom feed available, so we need to make it resilient to that scenario.

This uses `Artist#updated_at` as a fallback for the feed's `updated` property.

I also had to add the top-level `author` property, because otherwise the atom feed would be invalid when it has no entries. It seemed simpler to add it in all scenarios; not just when there were no entries.

[1]: https://app.rollbar.com/a/gofreerange/fix/item/jam/122