### PR TITLE
Promote successful CI builds to production branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,18 @@ jobs:
           FERRUM_PROCESS_TIMEOUT: 30
           FERRUM_DEFAULT_TIMEOUT: 30
         run: bin/rails test:all
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs:
+      - linters
+      - tests
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Promote main -> production
+        run: |
+          git checkout production
+          git merge main
+          git push origin production


### PR DESCRIPTION
Like we do in [this commit][1] in Mission Patch.

If we then configure Render to auto-deploy from the `production` branch instead of `main` as per [this commit][2], this will ensure we only deploy after a successful CI build. Note that this PR will have no significant effect until we make the latter change to the Render configuration.

[1]: https://github.com/freerange/mission-patch.svelte/commit/ced0321715c5e9055b374e0475f2012d270c1e21
[2]: https://github.com/freerange/mission-patch.svelte/commit/3cc6e32d0aa7a260246828d01335633e3ba0ca0a