### PR TITLE
Upload system test screenshots in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
           FERRUM_DEFAULT_TIMEOUT: 30
         run: bin/rails test:all
 
+      - name: Upload system test screenshots
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v5
+        with:
+          name: System test screenshots
+          path: tmp/screenshots
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest


### PR DESCRIPTION
Rails system tests are configured to automatically save a screenshot in `tmp/screenshots` on failure. I've seen a few flakey (?) system test failures in CI and I'm hoping this will help us diagnose them.

I've added a temporary commit to trigger a system test failure so I can check this PR is working. I plan to remove that before merging.