### PR TITLE
Handle multiple sessions in take_failed_screenshot

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,6 +2,7 @@
 
 require 'test_helper'
 require 'capybara/cuprite'
+require 'support/screenshot_helper_with_multiple_sessions'
 
 Capybara.javascript_driver = :cuprite
 Capybara.register_driver(:cuprite) do |app|

--- a/test/support/screenshot_helper_with_multiple_sessions.rb
+++ b/test/support/screenshot_helper_with_multiple_sessions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'action_dispatch/system_testing/test_helpers/screenshot_helper'
+
+module ScreenshotHelperWithMultipleSessions
+  def take_failed_screenshot
+    return unless failed? && supports_screenshot?
+
+    Capybara.send(:session_pool).each do |name, session|
+      showing_html = html_from_env?
+
+      html_path = "#{prefixed_path(name)}.html"
+      image_path = "#{prefixed_path(name)}.png"
+
+      session.save_page(html_path) if showing_html
+      session.save_screenshot(image_path)
+
+      message = "[Screenshot Image]: #{image_path}\n"
+      message << "[Screenshot HTML]: #{html_path}\n" if showing_html
+      puts message
+    end
+  end
+
+  private
+
+  def prefixed_path(name)
+    session_name = name.split(':')[1].underscore
+    Rails.root.join(screenshots_dir, [session_name, image_name].join('_'))
+  end
+end
+
+ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper.prepend(
+  ScreenshotHelperWithMultipleSessions
+)


### PR DESCRIPTION
The built-in screenshotting that happens when a system test fails is implemented in [`ActionDispatch::SystemTesting::TestHelpers::ScreenshotHelper#take_failed_screenshot`][1].

However, it only captures a screenshot for the default Capybara session. We're using multiple sessions in some of our system tests and if a failure happens in one of those, we get no useful information in the screenshot.

While it's not ideal that I'm monkey-patching the method or calling a private `Capybara` method, I think it's worth it in this case, given the consequences of it breaking are not hugely significant. I've tried to reproduce as much of the original behaviour as possible, but I haven't bothered trying to make the in-terminal image stuff work.

[1]: https://api.rubyonrails.org/v8.0.2.1/classes/ActionDispatch/SystemTesting/TestHelpers/ScreenshotHelper.html#method-i-take_failed_screenshot