### PR TITLE
Fix flakey CreatingAnAlbumTest system test

### DIFF
--- a/test/system/creating_an_album_test.rb
+++ b/test/system/creating_an_album_test.rb
@@ -90,6 +90,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
       end
 
       click_on 'Save'
+      assert_text 'This album is published'
     end
 
     perform_enqueued_jobs


### PR DESCRIPTION
I've been seeing a lot of CI build failures at line 106 which seem to be caused by the preview for a track not being available. This means the `assert_has_playable_track` assertion fails, because the `player#playTrack` action hasn't been added.

My hypothesis is that the `MultipleUploadController` Stimulus controller was sometimes failing to complete the upload of the new track from the album edit page *before* the call to `perform_enqueued_jobs` which then runs the transcoding job(s). This in turn meant the track preview was not ready when the "listener" assertions were made against the album page.

By asserting that the "This album is published" text is present after clicking "Save" on the album edit page, we can hopefully be a bit more confident that the track has been uploaded. However, this might not be sufficient, because it's not obvious we're waiting for the `MultipleUploadController` to complete before redirecting the "artist" to the album show page where the "This album is published" message is displayed.