### PR TITLE
Use `*_path` route helper vs `*_url` when possible

### DIFF
--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -19,7 +19,7 @@ class AlbumsController < ApplicationController
   def create
     if @album.save
       @album.transcode_tracks
-      redirect_to artist_album_url(@album.artist, @album), notice: 'Album was successfully created.'
+      redirect_to artist_album_path(@album.artist, @album), notice: 'Album was successfully created.'
     else
       render :new, status: :unprocessable_content
     end
@@ -27,7 +27,7 @@ class AlbumsController < ApplicationController
 
   def update
     if @album.update(album_params)
-      redirect_to artist_album_url(@album.artist, @album), notice: 'Artist was successfully updated.'
+      redirect_to artist_album_path(@album.artist, @album), notice: 'Artist was successfully updated.'
     else
       render :edit, status: :unprocessable_content
     end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -34,7 +34,10 @@ class ArtistsController < ApplicationController
     respond_to do |format|
       if @artist.save
         format.html do
-          redirect_to edit_artist_url(@artist), notice: 'Artist was successfully created. You can now add albums below.'
+          redirect_to(
+            edit_artist_path(@artist),
+            notice: 'Artist was successfully created. You can now add albums below.'
+          )
         end
         format.json { render :show, status: :created, location: @artist }
       else
@@ -49,7 +52,7 @@ class ArtistsController < ApplicationController
 
     respond_to do |format|
       if @artist.update(artist_params)
-        format.html { redirect_to artist_url(@artist), notice: 'Artist was successfully updated.' }
+        format.html { redirect_to artist_path(@artist), notice: 'Artist was successfully updated.' }
         format.json { render :show, status: :ok, location: @artist }
       else
         format.html { render :edit, status: :unprocessable_content }
@@ -63,7 +66,7 @@ class ArtistsController < ApplicationController
     @artist.destroy
 
     respond_to do |format|
-      format.html { redirect_to artists_url, notice: 'Artist was successfully destroyed.' }
+      format.html { redirect_to artists_path, notice: 'Artist was successfully destroyed.' }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/interests_controller.rb
+++ b/app/controllers/interests_controller.rb
@@ -13,7 +13,7 @@ class InterestsController < ApplicationController
 
     if @interest.save
       InterestsMailer.confirm(@interest).deliver_later
-      redirect_to thankyou_url
+      redirect_to thankyou_path
     else
       render :new, status: :unprocessable_content
     end
@@ -24,9 +24,9 @@ class InterestsController < ApplicationController
 
     if interest
       interest.email_activate
-      redirect_to confirmation_url
+      redirect_to confirmation_path
     else
-      redirect_to root_url
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/payout_details_controller.rb
+++ b/app/controllers/payout_details_controller.rb
@@ -8,7 +8,7 @@ class PayoutDetailsController < ApplicationController
     authorize @payout_detail
 
     if @payout_detail.save
-      redirect_to account_url, notice: 'Payout details added'
+      redirect_to account_path, notice: 'Payout details added'
     else
       render 'users/show', status: :unprocessable_content
     end
@@ -21,7 +21,7 @@ class PayoutDetailsController < ApplicationController
     authorize @payout_detail
 
     if @payout_detail.update(payout_detail_params)
-      redirect_to account_url, notice: 'Payout details updated'
+      redirect_to account_path, notice: 'Payout details updated'
     else
       render 'users/show', status: :unprocessable_content
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,8 +30,8 @@
       <footer class="flex flex-row justify-between mt-2 mb-4 text-slate-400 text-sm px-2 sm:px-0">
         <div class="flex flex-row gap-6">
           <div>
-            <p><%= link_to "About", about_url, class: "underline" %></p>
-            <p><%= link_to "Terms of use", terms_url, class: "underline" %></p>
+            <p><%= link_to "About", about_path, class: "underline" %></p>
+            <p><%= link_to "Terms of use", terms_path, class: "underline" %></p>
           </div>
           <div>
             <p><a href="https://www.instagram.com/jamdotcoop/" class="underline">Instagram</a></p>

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -15,11 +15,11 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def log_in_as(user)
-    visit log_in_url
+    visit log_in_path
     fill_in :email, with: user.email
     fill_in :password, with: 'Secret1*3*5*'
     click_on 'Log in'
-    assert_current_path root_url
+    assert_current_path root_path
     user
   end
 

--- a/test/controllers/albums_controller_test.rb
+++ b/test/controllers/albums_controller_test.rb
@@ -10,19 +10,19 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
   end
 
   test '#show' do
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
     assert_response :success
   end
 
   test '#show shows a buy button when album is published' do
     @album.published!
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
     assert_select 'button', text: 'Buy'
   end
 
   test '#show disables buy button when album is draft' do
     @album.draft!
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
     assert_select 'button[disabled=disabled]', text: 'Buy'
   end
 
@@ -30,7 +30,7 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
     create(:purchase, album: @album, price: @album.price, user: @user)
     @album.published!
 
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
 
     assert_select 'button', text: 'Buy', count: 0
     assert_select 'p', text: 'You own this album:'
@@ -40,7 +40,7 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
     track = create(:track, album: @album)
     create(:transcode, track:, format: :mp3v0)
 
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
 
     assert_select 'li', "#{track.title} mp3v0"
   end
@@ -48,29 +48,29 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
   test '#show shows the release date of the album' do
     @album.update(released_on: Date.parse('2023-06-20'))
 
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
 
     assert_select 'p', 'Released: June 20, 2023'
   end
 
   test '#new' do
-    get new_artist_album_url(@album.artist)
+    get new_artist_album_path(@album.artist)
     assert_response :success
   end
 
   test '#create' do
     assert_difference('Album.count') do
-      post artist_albums_url(@album.artist), params: {
+      post artist_albums_path(@album.artist), params: {
         album: { title: 'Example', cover: fixture_file_upload('cover.png'), license_id: License.first.id }
       }
     end
 
-    assert_redirected_to artist_album_url(@album.artist, Album.last)
+    assert_redirected_to artist_album_path(@album.artist, Album.last)
   end
 
   test '#create enqueues transcoding' do
     assert_enqueued_with(job: TranscodeJob) do
-      post artist_albums_url(@album.artist), params: {
+      post artist_albums_path(@album.artist), params: {
         album: { title: 'Example',
                  cover: fixture_file_upload('cover.png'),
                  license_id: License.first.id,
@@ -80,19 +80,19 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
   end
 
   test '#edit' do
-    get edit_artist_album_url(@album.artist, @album)
+    get edit_artist_album_path(@album.artist, @album)
     assert_response :success
   end
 
   test '#update' do
-    patch artist_album_url(@album.artist, @album), params: { album: { title: 'Example' } }
-    assert_redirected_to artist_album_url(@album.artist, @album)
+    patch artist_album_path(@album.artist, @album), params: { album: { title: 'Example' } }
+    assert_redirected_to artist_album_path(@album.artist, @album)
   end
 
   test '#update accepts attributes for tracks' do
     track = create(:track, album: @album, title: 'Old name')
 
-    patch artist_album_url(@album.artist, @album),
+    patch artist_album_path(@album.artist, @album),
           params: { album: { title: 'Example', tracks_attributes: { id: track.id, title: 'New name' } } }
 
     assert_equal 'New name', track.reload.title
@@ -102,7 +102,7 @@ class AlbumsControllerTestSignedInAsAdmin < ActionDispatch::IntegrationTest
     track = create(:track, album: @album, title: 'Old name')
 
     assert_difference('Track.count', -1, 'A Track should be destroyed') do
-      patch artist_album_url(@album.artist, @album),
+      patch artist_album_path(@album.artist, @album),
             params: { album: { title: 'Example', tracks_attributes: { id: track.id, _destroy: true } } }
     end
   end
@@ -117,27 +117,27 @@ class AlbumsControllerTestSignedInAsArtist < ActionDispatch::IntegrationTest
   end
 
   test '#show has an edit button' do
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
 
     assert_select 'a', text: 'Edit album'
   end
 
   test '#show indicates draft visibility of album' do
     @album.draft!
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
     assert_match 'Only you can see it', response.body
   end
 
   test '#show indicates published visibility of album' do
     @album.published!
-    get artist_album_url(@album.artist, @album)
+    get artist_album_path(@album.artist, @album)
     assert_match 'Everyone can see it', response.body
   end
 end
 
 class AlbumsControllerTestSignedOut < ActionDispatch::IntegrationTest
   test '#index' do
-    get albums_url
+    get albums_path
     assert_response :success
   end
 
@@ -147,7 +147,7 @@ class AlbumsControllerTestSignedOut < ActionDispatch::IntegrationTest
     create(:published_album, title: 'Newer Album', first_published_on: 1.day.ago, artist:)
     create(:draft_album, title: 'Draft Album', artist:)
 
-    get albums_url(format: :atom)
+    get albums_path(format: :atom)
 
     feed = RSS::Parser.parse(response.body)
     assert_equal 'Albums on jam.coop', feed.title.content
@@ -157,38 +157,38 @@ class AlbumsControllerTestSignedOut < ActionDispatch::IntegrationTest
   end
 
   test '#show' do
-    get artist_album_url(album.artist, album)
+    get artist_album_path(album.artist, album)
     assert_response :success
   end
 
   test '#show not authorized when album is draft' do
     draft_album = create(:draft_album)
-    previous_url = artist_url(draft_album.artist)
+    previous_path = artist_path(draft_album.artist)
 
-    get artist_album_url(draft_album.artist, draft_album), headers: { 'HTTP_REFERER' => previous_url }
+    get artist_album_path(draft_album.artist, draft_album), headers: { 'HTTP_REFERER' => previous_path }
 
-    assert_redirected_to previous_url
+    assert_redirected_to previous_path
     assert_equal 'You are not authorized to perform this action.', flash[:alert]
   end
 
   test '#new' do
-    get new_artist_album_url(album.artist)
-    assert_redirected_to log_in_url
+    get new_artist_album_path(album.artist)
+    assert_redirected_to log_in_path
   end
 
   test '#create' do
-    post artist_albums_url(album.artist), params: { album: { title: 'Example' } }
-    assert_redirected_to log_in_url
+    post artist_albums_path(album.artist), params: { album: { title: 'Example' } }
+    assert_redirected_to log_in_path
   end
 
   test '#edit' do
-    get edit_artist_album_url(album.artist, album)
-    assert_redirected_to log_in_url
+    get edit_artist_album_path(album.artist, album)
+    assert_redirected_to log_in_path
   end
 
   test '#update' do
-    patch artist_album_url(album.artist, album), params: { album: { title: 'Example' } }
-    assert_redirected_to log_in_url
+    patch artist_album_path(album.artist, album), params: { album: { title: 'Example' } }
+    assert_redirected_to log_in_path
   end
 
   private

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -10,17 +10,17 @@ class ArtistsControllerTestSignedIn < ActionDispatch::IntegrationTest
   end
 
   test '#index' do
-    get artists_url
+    get artists_path
     assert_response :success
   end
 
   test '#index should show both listed and unlisted artist' do
-    get artists_url
+    get artists_path
     assert_select 'p', "#{@artist.name} (unlisted)"
 
     @artist.albums << create(:published_album)
 
-    get artists_url
+    get artists_path
     assert_select 'p', @artist.name
   end
 
@@ -35,7 +35,7 @@ class ArtistsControllerTestSignedIn < ActionDispatch::IntegrationTest
     unlisted_artist = create(:artist, name: 'Unlisted Artist')
     create(:draft_album, artist: unlisted_artist)
 
-    get artists_url(format: :atom)
+    get artists_path(format: :atom)
 
     feed = RSS::Parser.parse(response.body)
     assert_equal 'Artists on jam.coop', feed.title.content
@@ -47,7 +47,7 @@ class ArtistsControllerTestSignedIn < ActionDispatch::IntegrationTest
   test '#show should include published albums' do
     @artist.albums << create(:published_album, title: 'Album Title')
 
-    get artist_url(@artist)
+    get artist_path(@artist)
 
     assert_select 'p', 'Album Title'
   end
@@ -55,48 +55,48 @@ class ArtistsControllerTestSignedIn < ActionDispatch::IntegrationTest
   test '#show should include draft albums' do
     @artist.albums << create(:draft_album, title: 'Album Title')
 
-    get artist_url(@artist)
+    get artist_path(@artist)
 
     assert_select 'p', 'draft'
   end
 
   test '#new' do
-    get new_artist_url
+    get new_artist_path
     assert_response :success
   end
 
   test '#create' do
     assert_difference('Artist.count') do
-      post artists_url, params: { artist: { name: 'Example' } }
+      post artists_path, params: { artist: { name: 'Example' } }
     end
 
-    assert_redirected_to edit_artist_url(Artist.last)
+    assert_redirected_to edit_artist_path(Artist.last)
   end
 
   test '#create associates the new artist with the current user' do
-    post artists_url, params: { artist: { name: 'Example' } }
+    post artists_path, params: { artist: { name: 'Example' } }
 
     assert_equal @user, Artist.last.user
 
-    assert_redirected_to edit_artist_url(Artist.last)
+    assert_redirected_to edit_artist_path(Artist.last)
   end
 
   test '#edit' do
-    get edit_artist_url(@artist)
+    get edit_artist_path(@artist)
     assert_response :success
   end
 
   test '#update' do
-    patch artist_url(@artist), params: { artist: { name: 'New name' } }
-    assert_redirected_to artist_url(@artist)
+    patch artist_path(@artist), params: { artist: { name: 'New name' } }
+    assert_redirected_to artist_path(@artist)
   end
 
   test '#destroy' do
     assert_difference('Artist.count', -1) do
-      delete artist_url(@artist)
+      delete artist_path(@artist)
     end
 
-    assert_redirected_to artists_url
+    assert_redirected_to artists_path
   end
 end
 
@@ -112,7 +112,7 @@ class ArtistsControllerTestSignedInArtist < ActionDispatch::IntegrationTest
   test '#show should include published albums' do
     @artist.albums << create(:published_album, title: 'Album Title')
 
-    get artist_url(@artist)
+    get artist_path(@artist)
 
     assert_select 'p', 'Album Title'
   end
@@ -120,7 +120,7 @@ class ArtistsControllerTestSignedInArtist < ActionDispatch::IntegrationTest
   test '#show should include draft albums' do
     @artist.albums << create(:draft_album, title: 'Album Title')
 
-    get artist_url(@artist)
+    get artist_path(@artist)
 
     assert_select 'p', 'draft'
   end
@@ -132,22 +132,22 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
   end
 
   test '#index' do
-    get artists_url
+    get artists_path
     assert_response :success
   end
 
   test '#index should only show listed artists' do
-    get artists_url
+    get artists_path
     assert_select 'p', { count: 0, text: @artist.name }
 
     @artist.albums << create(:published_album)
 
-    get artists_url
+    get artists_path
     assert_select 'p', { text: @artist.name }
   end
 
   test '#index includes auto-discovery link for atom feed' do
-    get artists_url
+    get artists_path
 
     url = artists_url(format: :atom)
     assert_select "head link[rel='alternate'][type='application/atom+xml'][href='#{url}']"
@@ -164,7 +164,7 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
     unlisted_artist = create(:artist, name: 'Unlisted Artist')
     create(:draft_album, artist: unlisted_artist)
 
-    get artists_url(format: :atom)
+    get artists_path(format: :atom)
 
     feed = RSS::Parser.parse(response.body)
     assert_equal 'Artists on jam.coop', feed.title.content
@@ -176,7 +176,7 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
   test '#show should include published albums' do
     @artist.albums << create(:published_album, title: 'Album Title')
 
-    get artist_url(@artist)
+    get artist_path(@artist)
 
     assert_select 'p', 'Album Title'
   end
@@ -184,13 +184,13 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
   test '#show should not include draft albums' do
     @artist.albums << create(:draft_album, title: 'Album Title')
 
-    get artist_url(@artist)
+    get artist_path(@artist)
 
     assert_select 'p', { text: 'draft', count: 0 }
   end
 
   test '#show includes auto-discovery link for atom feed' do
-    get artist_url(@artist)
+    get artist_path(@artist)
 
     url = artist_url(@artist, format: :atom)
     assert_select "head link[rel='alternate'][type='application/atom+xml'][href='#{url}']"
@@ -201,7 +201,7 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
     @artist.albums << create(:published_album, title: 'Newer', released_on: 1.day.ago)
     @artist.albums << create(:draft_album, title: 'Draft', released_on: 0.days.ago)
 
-    get artist_url(@artist, format: :atom)
+    get artist_path(@artist, format: :atom)
 
     feed = RSS::Parser.parse(response.body)
     assert_equal "#{@artist.name} albums on jam.coop", feed.title.content
@@ -214,7 +214,7 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
   test '#show with atom format for artist with no published albums should render atom feed' do
     @artist.albums << create(:draft_album)
 
-    get artist_url(@artist, format: :atom)
+    get artist_path(@artist, format: :atom)
 
     feed = RSS::Parser.parse(response.body)
     assert_equal "#{@artist.name} albums on jam.coop", feed.title.content
@@ -223,27 +223,27 @@ class ArtistsControllerTestSignedOut < ActionDispatch::IntegrationTest
   end
 
   test '#new' do
-    get new_artist_url
+    get new_artist_path
     assert_redirected_to log_in_path
   end
 
   test '#create' do
-    post artists_url, params: { artist: { name: 'Example' } }
+    post artists_path, params: { artist: { name: 'Example' } }
     assert_redirected_to log_in_path
   end
 
   test '#edit' do
-    get edit_artist_url(@artist)
+    get edit_artist_path(@artist)
     assert_redirected_to log_in_path
   end
 
   test '#update' do
-    patch artist_url(@artist), params: { artist: { name: 'New name' } }
+    patch artist_path(@artist), params: { artist: { name: 'New name' } }
     assert_redirected_to log_in_path
   end
 
   test '#destroy' do
-    delete artist_url(@artist)
+    delete artist_path(@artist)
 
     assert_redirected_to log_in_path
   end

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -9,20 +9,20 @@ class CollectionControllerTestSignedIn < ActionDispatch::IntegrationTest
   end
 
   test '#show' do
-    get collection_url
+    get collection_path
     assert_response :success
   end
 
   test '#show includes albums the user has purchased' do
     purchase = create(:purchase, user: @user)
 
-    get collection_url
+    get collection_path
 
     assert_select 'p', purchase.album.title
   end
 
   test '#show indicates when the user has no purchases' do
-    get collection_url
+    get collection_path
 
     assert_select 'p', "There's nothing in your collection at the moment."
   end
@@ -30,7 +30,7 @@ end
 
 class CollectionControllerTestSignedOut < ActionDispatch::IntegrationTest
   test '#show' do
-    get account_url
+    get account_path
     assert_redirected_to log_in_path
   end
 end

--- a/test/controllers/identity/email_verifications_controller_test.rb
+++ b/test/controllers/identity/email_verifications_controller_test.rb
@@ -11,25 +11,25 @@ module Identity
 
     test 'should send a verification email' do
       assert_enqueued_email_with UserMailer, :email_verification, params: { user: @user } do
-        post identity_email_verification_url
+        post identity_email_verification_path
       end
 
-      assert_redirected_to root_url
+      assert_redirected_to root_path
     end
 
     test 'should verify email' do
       sid = @user.email_verification_tokens.create.signed_id(expires_in: 2.days)
 
-      get identity_email_verification_url(sid:, email: @user.email)
-      assert_redirected_to root_url
+      get identity_email_verification_path(sid:, email: @user.email)
+      assert_redirected_to root_path
     end
 
     test 'should not verify email with expired token' do
       sid_exp = @user.email_verification_tokens.create.signed_id(expires_in: 0.minutes)
 
-      get identity_email_verification_url(sid: sid_exp, email: @user.email)
+      get identity_email_verification_path(sid: sid_exp, email: @user.email)
 
-      assert_redirected_to root_url
+      assert_redirected_to root_path
       assert_equal 'That email verification link is invalid', flash[:alert]
     end
   end

--- a/test/controllers/identity/emails_controller_test.rb
+++ b/test/controllers/identity/emails_controller_test.rb
@@ -9,12 +9,12 @@ module Identity
     end
 
     test 'should update email' do
-      patch identity_email_url, params: { email: 'new_email@hey.com', current_password: 'Secret1*3*5*' }
+      patch identity_email_path, params: { email: 'new_email@hey.com', current_password: 'Secret1*3*5*' }
       assert_redirected_to account_path
     end
 
     test 'should not update email with wrong current password' do
-      patch identity_email_url, params: { email: 'new_email@hey.com', current_password: 'SecretWrong1*3' }
+      patch identity_email_path, params: { email: 'new_email@hey.com', current_password: 'SecretWrong1*3' }
 
       assert_redirected_to account_path
       assert_equal 'The password you entered is incorrect', flash[:emails_update_password_incorrect]

--- a/test/controllers/identity/password_resets_controller_test.rb
+++ b/test/controllers/identity/password_resets_controller_test.rb
@@ -9,31 +9,31 @@ module Identity
     end
 
     test 'should get new' do
-      get new_identity_password_reset_url
+      get new_identity_password_reset_path
       assert_response :success
     end
 
     test 'should get edit' do
       sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
 
-      get edit_identity_password_reset_url(sid:)
+      get edit_identity_password_reset_path(sid:)
       assert_response :success
     end
 
     test 'should send a password reset email' do
       assert_enqueued_email_with UserMailer, :password_reset, params: { user: @user } do
-        post identity_password_reset_url, params: { email: @user.email }
+        post identity_password_reset_path, params: { email: @user.email }
       end
 
-      assert_redirected_to log_in_url
+      assert_redirected_to log_in_path
     end
 
     test 'should not send a password reset email to a nonexistent email' do
       assert_no_enqueued_emails do
-        post identity_password_reset_url, params: { email: 'invalid_email@hey.com' }
+        post identity_password_reset_path, params: { email: 'invalid_email@hey.com' }
       end
 
-      assert_redirected_to new_identity_password_reset_url
+      assert_redirected_to new_identity_password_reset_path
       assert_equal "You can't reset your password until you verify your email", flash[:alert]
     end
 
@@ -41,27 +41,27 @@ module Identity
       @user.update! verified: false
 
       assert_no_enqueued_emails do
-        post identity_password_reset_url, params: { email: @user.email }
+        post identity_password_reset_path, params: { email: @user.email }
       end
 
-      assert_redirected_to new_identity_password_reset_url
+      assert_redirected_to new_identity_password_reset_path
       assert_equal "You can't reset your password until you verify your email", flash[:alert]
     end
 
     test 'should update password' do
       sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
 
-      patch identity_password_reset_url,
+      patch identity_password_reset_path,
             params: { sid:, password: 'Secret6*4*2*', password_confirmation: 'Secret6*4*2*' }
-      assert_redirected_to log_in_url
+      assert_redirected_to log_in_path
     end
 
     test 'should not update password with expired token' do
       sid_exp = @user.password_reset_tokens.create.signed_id(expires_in: 0.minutes)
 
-      patch identity_password_reset_url,
+      patch identity_password_reset_path,
             params: { sid: sid_exp, password: 'Secret6*4*2*', password_confirmation: 'Secret6*4*2*' }
-      assert_redirected_to new_identity_password_reset_url
+      assert_redirected_to new_identity_password_reset_path
       assert_equal 'That password reset link is invalid', flash[:alert]
     end
   end

--- a/test/controllers/interests_controller_test.rb
+++ b/test/controllers/interests_controller_test.rb
@@ -9,27 +9,27 @@ class InterestsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create should create interest' do
     assert_difference('Interest.count') do
-      post interests_url, params: { interest: { email: @interest.email } }
+      post interests_path, params: { interest: { email: @interest.email } }
     end
 
-    assert_redirected_to thankyou_url
+    assert_redirected_to thankyou_path
   end
 
   test '#create should find an existing record if one exists' do
     @interest.save
 
     assert_no_difference('Interest.count') do
-      post interests_url, params: { interest: { email: @interest.email } }
+      post interests_path, params: { interest: { email: @interest.email } }
     end
 
-    assert_redirected_to thankyou_url
+    assert_redirected_to thankyou_path
   end
 
   test '#create should send a confirmation email' do
     @interest.save
 
     assert_enqueued_emails 1 do
-      post interests_url, params: { interest: { email: @interest.email } }
+      post interests_path, params: { interest: { email: @interest.email } }
     end
   end
 
@@ -37,15 +37,15 @@ class InterestsControllerTest < ActionDispatch::IntegrationTest
     @interest.save
 
     assert_changes -> { @interest.reload.email_confirmed } do
-      get confirm_email_interest_url(@interest.confirm_token)
+      get confirm_email_interest_path(@interest.confirm_token)
     end
 
-    assert_redirected_to confirmation_url
+    assert_redirected_to confirmation_path
   end
 
   test '#confirm_email should handle unknown confirmation tokens' do
-    get confirm_email_interest_url('invalid-token')
+    get confirm_email_interest_path('invalid-token')
 
-    assert_redirected_to root_url
+    assert_redirected_to root_path
   end
 end

--- a/test/controllers/pages_controller_test.rb
+++ b/test/controllers/pages_controller_test.rb
@@ -4,12 +4,12 @@ require 'test_helper'
 
 class PagesControllerTest < ActionDispatch::IntegrationTest
   test 'should get home' do
-    get root_url
+    get root_path
     assert_response :success
   end
 
   test 'should get about' do
-    get about_url
+    get about_path
     assert_response :success
   end
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -8,13 +8,13 @@ class PasswordsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update password' do
-    patch password_url,
+    patch password_path,
           params: { current_password: 'Secret1*3*5*', password: 'Secret6*4*2*', password_confirmation: 'Secret6*4*2*' }
     assert_redirected_to account_path
   end
 
   test 'should not update password with wrong current password' do
-    patch password_url,
+    patch password_path,
           params: { current_password: 'SecretWrong1*3', password: 'Secret6*4*2*',
                     password_confirmation: 'Secret6*4*2*' }
 

--- a/test/controllers/payout_details_controller_test.rb
+++ b/test/controllers/payout_details_controller_test.rb
@@ -8,22 +8,22 @@ class PayoutDetailsControllerTest < ActionDispatch::IntegrationTest
     log_in_as(@user)
   end
 
-  test '#create creates a new PayoutDetail and redirects to account_url' do
+  test '#create creates a new PayoutDetail and redirects to account_path' do
     assert_difference('PayoutDetail.count') do
-      post payout_detail_url, params: { payout_detail: { name: 'Alice', country: 'country' } }
+      post payout_detail_path, params: { payout_detail: { name: 'Alice', country: 'country' } }
     end
 
-    assert_redirected_to account_url
+    assert_redirected_to account_path
   end
 
   test '#create assigns the name in the param to the PayoutDetail' do
-    post payout_detail_url, params: { payout_detail: { name: 'Alice', country: 'country' } }
+    post payout_detail_path, params: { payout_detail: { name: 'Alice', country: 'country' } }
 
     assert_equal 'Alice', PayoutDetail.last.name
   end
 
   test '#create associates the PayoutDetail with the current user' do
-    post payout_detail_url, params: { payout_detail: { name: 'Alice', country: 'country' } }
+    post payout_detail_path, params: { payout_detail: { name: 'Alice', country: 'country' } }
 
     assert_equal @user, PayoutDetail.last.user
   end
@@ -31,14 +31,14 @@ class PayoutDetailsControllerTest < ActionDispatch::IntegrationTest
   test '#update updates fields and redirects to account page' do
     create(:payout_detail, user: @user)
 
-    patch payout_detail_url, params: { payout_detail: { name: 'Bob', country: 'country' } }
+    patch payout_detail_path, params: { payout_detail: { name: 'Bob', country: 'country' } }
 
     assert_equal 'Bob', @user.reload.payout_detail.name
-    assert_redirected_to account_url
+    assert_redirected_to account_path
   end
 
   test '#update 404s if user has no payout detail' do
-    patch payout_detail_url, params: { payout_detail: { name: 'Bob', country: 'country' } }
+    patch payout_detail_path, params: { payout_detail: { name: 'Bob', country: 'country' } }
 
     assert_response :not_found
   end
@@ -46,7 +46,7 @@ end
 
 class PayoutDetailsControllerTestSignedOut < ActionDispatch::IntegrationTest
   test '#update' do
-    patch payout_detail_url
-    assert_redirected_to log_in_url
+    patch payout_detail_path
+    assert_redirected_to log_in_path
   end
 end

--- a/test/controllers/purchases_controller_test.rb
+++ b/test/controllers/purchases_controller_test.rb
@@ -4,14 +4,14 @@ require 'test_helper'
 
 class PurchasesControllerTest < ActionDispatch::IntegrationTest
   test 'show' do
-    get purchase_url(create(:purchase))
+    get purchase_path(create(:purchase))
     assert_response :success
   end
 
   test 'should get new' do
     album = create(:album)
 
-    get new_artist_album_purchase_url(album.artist, album)
+    get new_artist_album_purchase_path(album.artist, album)
 
     assert_response :success
   end
@@ -21,7 +21,7 @@ class PurchasesControllerTest < ActionDispatch::IntegrationTest
     service = stub(create_checkout_session: stub(success?: true, url: 'https://stripe.example.com', id: 'cs_test_foo'))
     StripeService.expects(:new).returns(service)
 
-    post artist_album_purchases_url(album.artist, album),
+    post artist_album_purchases_path(album.artist, album),
          params: { purchase: { price: album.price, contact_opt_in: true } }
 
     assert_redirected_to 'https://stripe.example.com'
@@ -32,11 +32,11 @@ class PurchasesControllerTest < ActionDispatch::IntegrationTest
     service = stub(create_checkout_session: stub(success?: false, error: 'error message'))
     StripeService.expects(:new).returns(service)
 
-    post artist_album_purchases_url(album.artist, album),
+    post artist_album_purchases_path(album.artist, album),
          params: { purchase: { price: album.price, contact_opt_in: true } }
 
     assert_equal 'error message', flash[:alert]
-    assert_redirected_to new_artist_album_purchase_url(album.artist, album)
+    assert_redirected_to new_artist_album_purchase_path(album.artist, album)
   end
 
   test 'create creates a new purchase' do
@@ -45,7 +45,7 @@ class PurchasesControllerTest < ActionDispatch::IntegrationTest
     StripeService.expects(:new).returns(service)
 
     assert_difference('Purchase.count') do
-      post artist_album_purchases_url(album.artist, album),
+      post artist_album_purchases_path(album.artist, album),
            params: { purchase: { price: album.price, contact_opt_in: true } }
     end
   end
@@ -55,7 +55,7 @@ class PurchasesControllerTest < ActionDispatch::IntegrationTest
     service = stub(create_checkout_session: stub(success?: true, url: 'https://stripe.example.com', id: 'cs_test_foo'))
     StripeService.expects(:new).returns(service)
 
-    post artist_album_purchases_url(album.artist, album),
+    post artist_album_purchases_path(album.artist, album),
          params: { purchase: { price: album.price, contact_opt_in: true } }
 
     assert_equal true, Purchase.last.contact_opt_in
@@ -66,7 +66,7 @@ class PurchasesControllerTest < ActionDispatch::IntegrationTest
     service = stub(create_checkout_session: stub(success?: true, url: 'https://stripe.example.com', id: 'cs_test_foo'))
     StripeService.expects(:new).returns(service)
 
-    post artist_album_purchases_url(album.artist, album),
+    post artist_album_purchases_path(album.artist, album),
          params: { purchase: { price: album.price, contact_opt_in: true } }
 
     assert_equal 'cs_test_foo', Purchase.last.stripe_session_id
@@ -79,7 +79,7 @@ class PurchasesControllerTest < ActionDispatch::IntegrationTest
     service = stub(create_checkout_session: stub(success?: true, url: 'https://stripe.example.com', id: 'cs_test_foo'))
     StripeService.expects(:new).returns(service)
 
-    post artist_album_purchases_url(album.artist, album),
+    post artist_album_purchases_path(album.artist, album),
          params: { purchase: { price: album.price, contact_opt_in: true } }
 
     assert_equal user, Purchase.last.user
@@ -90,7 +90,7 @@ class PurchasesControllerTest < ActionDispatch::IntegrationTest
     service = stub(create_checkout_session: stub(success?: true, url: 'https://stripe.example.com', id: 'cs_test_foo'))
     StripeService.expects(:new).returns(service)
 
-    post artist_album_purchases_url(album.artist, album),
+    post artist_album_purchases_path(album.artist, album),
          params: { purchase: { price: album.price, contact_opt_in: true } }
 
     assert_nil Purchase.last.user

--- a/test/controllers/registrations_controller_test.rb
+++ b/test/controllers/registrations_controller_test.rb
@@ -12,7 +12,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#new should render a registration form' do
-    get sign_up_url
+    get sign_up_path
 
     assert_response :success
     assert_select "input[type='email']"
@@ -23,7 +23,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create creates a new user' do
     assert_difference('User.count') do
-      post sign_up_url, params: {
+      post sign_up_path, params: {
         email: 'user@example.com',
         password: 'Secret1*3*5*',
         password_confirmation: 'Secret1*3*5*'
@@ -32,7 +32,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#create sets a session token cookie' do
-    post sign_up_url, params: {
+    post sign_up_path, params: {
       email: 'user@example.com',
       password: 'Secret1*3*5*',
       password_confirmation: 'Secret1*3*5*'
@@ -42,7 +42,7 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#create redirects to the home page' do
-    post sign_up_url,
+    post sign_up_path,
          params: { email: 'user@example.com', password: 'Secret1*3*5*', password_confirmation: 'Secret1*3*5*' }
 
     assert_redirected_to root_path
@@ -50,20 +50,20 @@ class RegistrationsControllerTest < ActionDispatch::IntegrationTest
 
   test '#create sends an email verification email' do
     assert_enqueued_emails 1 do
-      post sign_up_url,
+      post sign_up_path,
            params: { email: 'user@example.com', password: 'Secret1*3*5*', password_confirmation: 'Secret1*3*5*' }
     end
   end
 
   test '#create shows an error if data is unprocessable' do
-    post sign_up_url, params: { email: '', password: '', password_confirmation: '' }
+    post sign_up_path, params: { email: '', password: '', password_confirmation: '' }
 
     assert_response :unprocessable_content
     assert_select 'h2', text: /errors prohibited this user from being saved/
   end
 
   test '#create makes a call to the cloudflare turnstile API to validate the request' do
-    post sign_up_url, params: {
+    post sign_up_path, params: {
       email: 'user@example.com',
       password: 'Secret1*3*5*',
       password_confirmation: 'Secret1*3*5*'

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -8,40 +8,40 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get new' do
-    get log_in_url
+    get log_in_path
     assert_response :success
   end
 
   test 'should sign in' do
-    post log_in_url, params: { email: @user.email, password: 'Secret1*3*5*' }
-    assert_redirected_to root_url
+    post log_in_path, params: { email: @user.email, password: 'Secret1*3*5*' }
+    assert_redirected_to root_path
 
-    get a_url_that_requires_authentication
+    get a_path_that_requires_authentication
     assert_response :success
   end
 
   test 'should not sign in with wrong credentials' do
-    post log_in_url, params: { email: @user.email, password: 'SecretWrong1*3' }
-    assert_redirected_to log_in_url(email_hint: @user.email)
+    post log_in_path, params: { email: @user.email, password: 'SecretWrong1*3' }
+    assert_redirected_to log_in_path(email_hint: @user.email)
     assert_equal 'That email or password is incorrect', flash[:alert]
 
-    get a_url_that_requires_authentication
-    assert_redirected_to log_in_url
+    get a_path_that_requires_authentication
+    assert_redirected_to log_in_path
   end
 
   test 'should sign out' do
     log_in_as @user
 
-    delete session_url(@user.sessions.last)
-    assert_redirected_to sessions_url
+    delete session_path(@user.sessions.last)
+    assert_redirected_to sessions_path
 
     follow_redirect!
-    assert_redirected_to log_in_url
+    assert_redirected_to log_in_path
   end
 
   private
 
-  def a_url_that_requires_authentication
-    account_url
+  def a_path_that_requires_authentication
+    account_path
   end
 end

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -6,7 +6,7 @@ class TagsControllerTest < ActionDispatch::IntegrationTest
   test '#show' do
     tag = create(:tag)
 
-    get tag_url(tag)
+    get tag_path(tag)
 
     assert_response :success
   end

--- a/test/controllers/tracks_controller_test.rb
+++ b/test/controllers/tracks_controller_test.rb
@@ -9,12 +9,12 @@ class TracksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should move track higher' do
-    post move_higher_track_url(@track)
-    assert_redirected_to artist_album_url(@track.artist, @track.album)
+    post move_higher_track_path(@track)
+    assert_redirected_to artist_album_path(@track.artist, @track.album)
   end
 
   test 'should move track lower' do
-    post move_lower_track_url(@track)
-    assert_redirected_to artist_album_url(@track.artist, @track.album)
+    post move_lower_track_path(@track)
+    assert_redirected_to artist_album_path(@track.artist, @track.album)
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -9,14 +9,14 @@ class UsersControllerTestSignedIn < ActionDispatch::IntegrationTest
   end
 
   test '#show' do
-    get account_url
+    get account_path
     assert_response :success
   end
 end
 
 class UserControllerTestSignedOut < ActionDispatch::IntegrationTest
   test '#show' do
-    get account_url
+    get account_path
     assert_redirected_to log_in_path
   end
 end

--- a/test/system/buying_an_album_test.rb
+++ b/test/system/buying_an_album_test.rb
@@ -10,7 +10,7 @@ class BuyingAnAlbumTest < ApplicationSystemTestCase
   end
 
   test 'purchasing an album' do
-    visit artist_album_url(@album.artist, @album)
+    visit artist_album_path(@album.artist, @album)
     click_on 'Buy'
     fill_in 'Price', with: @album.price
     click_on 'Checkout'

--- a/test/system/collection_test.rb
+++ b/test/system/collection_test.rb
@@ -11,39 +11,39 @@ class CollectionTest < ApplicationSystemTestCase
 
   test 'when a logged in user purchases an album it appears in their collection' do
     log_in_as(@user)
-    visit artist_album_url(@album.artist, @album)
+    visit artist_album_path(@album.artist, @album)
     click_on 'Buy'
     fill_in 'Price', with: @album.price
     click_on 'Checkout'
     fake_stripe_webhook_event_completed(@user)
-    visit collection_url
+    visit collection_path
     assert_text @album.title
     click_on @album.title
     assert_text 'You own this album'
   end
 
   test 'when a logged out user purchases an album it appears in their collection' do
-    visit artist_album_url(@album.artist, @album)
+    visit artist_album_path(@album.artist, @album)
     click_on 'Buy'
     fill_in 'Price', with: @album.price
     click_on 'Checkout'
     fake_stripe_webhook_event_completed(@user)
 
     log_in_as(@user)
-    visit collection_url
+    visit collection_path
     assert_text @album.title
   end
 
   test 'when someone purchases an album and then creates an account, the album appears in their collection' do
     user = build(:user, email: 'someone@example.com')
 
-    visit artist_album_url(@album.artist, @album)
+    visit artist_album_path(@album.artist, @album)
     click_on 'Buy'
     fill_in 'Price', with: @album.price
     click_on 'Checkout'
     fake_stripe_webhook_event_completed(user)
 
-    visit root_url
+    visit root_path
     click_on 'sign up'
     fill_in 'Email', with: user.email
     fill_in 'Password', with: 'Secret1*3*5*'
@@ -54,7 +54,7 @@ class CollectionTest < ApplicationSystemTestCase
     visit verify_email_url
     assert_text 'Thank you for verifying your email address'
 
-    visit collection_url
+    visit collection_path
     assert_text @album.title
   end
 

--- a/test/system/creating_an_album_test.rb
+++ b/test/system/creating_an_album_test.rb
@@ -11,7 +11,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
 
   test 'creating an album' do
     log_in_as(@artist_user)
-    visit edit_artist_url(@artist)
+    visit edit_artist_path(@artist)
     click_on 'Add album'
     fill_in 'Title', with: "A Hard Day's Night"
     attach_file 'Cover', Rails.root.join('test/fixtures/files/cover.png')
@@ -33,7 +33,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
     admin = create(:user, admin: true, email: 'admin@example.com')
     log_in_as(admin)
     album = Album.find_by(title: "A Hard Day's Night")
-    visit artist_album_url(album.artist, album)
+    visit artist_album_path(album.artist, album)
     within(admin_section) do
       assert_text 'And I Love Her'
       assert_text 'mp3v0'
@@ -46,7 +46,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
     log_in_as(@artist_user)
     album = create(:album, artist: @artist)
 
-    visit edit_artist_url(@artist, album)
+    visit edit_artist_path(@artist, album)
     assert_text album.title
     click_on album.title
     fill_in 'Title', with: 'New Title'
@@ -61,7 +61,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
     perform_enqueued_jobs
 
     using_session 'listener' do
-      visit artist_album_url(album.artist, album)
+      visit artist_album_path(album.artist, album)
 
       album.tracks.each do |track|
         assert_has_playable_track(track)
@@ -70,7 +70,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
 
     using_session 'artist' do
       log_in_as(@artist_user)
-      visit edit_artist_url(@artist)
+      visit edit_artist_path(@artist)
       assert_text album.title
       click_on album.title
 
@@ -96,7 +96,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
     perform_enqueued_jobs
 
     using_session 'listener' do
-      visit artist_album_url(album.artist, album)
+      visit artist_album_path(album.artist, album)
 
       assert_text 'Rename the first track'
       assert_text album.reload.tracks[1].title

--- a/test/system/identity/password_resets_test.rb
+++ b/test/system/identity/password_resets_test.rb
@@ -10,7 +10,7 @@ module Identity
     end
 
     test 'sending a password reset email' do
-      visit log_in_url
+      visit log_in_path
       click_on 'Forgot your password?'
 
       fill_in 'Email', with: @user.email
@@ -20,7 +20,7 @@ module Identity
     end
 
     test 'updating password' do
-      visit edit_identity_password_reset_url(sid: @sid)
+      visit edit_identity_password_reset_path(sid: @sid)
 
       fill_in 'New password', with: 'Secret6*4*2*'
       fill_in 'Confirm new password', with: 'Secret6*4*2*'

--- a/test/system/payout_details_test.rb
+++ b/test/system/payout_details_test.rb
@@ -9,7 +9,7 @@ class PayoutDetailsTest < ApplicationSystemTestCase
   end
 
   test 'adding payout details' do
-    visit account_url
+    visit account_path
 
     within(payout_details_section) do
       fill_in 'Name', with: 'John Lennon'
@@ -25,7 +25,7 @@ class PayoutDetailsTest < ApplicationSystemTestCase
   test 'updating payout details' do
     create(:payout_detail, user: @user)
 
-    visit account_url
+    visit account_path
 
     within(payout_details_section) do
       fill_in 'Name', with: 'John Smith'

--- a/test/system/publishing_an_album_test.rb
+++ b/test/system/publishing_an_album_test.rb
@@ -12,13 +12,13 @@ class PublishingAnAlbumTest < ApplicationSystemTestCase
 
   test 'publishing an album' do
     # Album does not appear in "recently released" section
-    visit root_url
+    visit root_path
     within(recently_released) do
       refute_text @album.title
     end
 
     # Artist sets visibility of album to published
-    visit artist_url(@album.artist)
+    visit artist_path(@album.artist)
     click_on @album.title.to_s
     click_on 'Edit'
     assert_checked_field 'Draft'
@@ -28,11 +28,11 @@ class PublishingAnAlbumTest < ApplicationSystemTestCase
     sign_out
 
     # Listener visits published album page
-    visit artist_url(@album.artist)
+    visit artist_path(@album.artist)
     click_on @album.title
 
     # Album appears in "recently released" section
-    visit root_url
+    visit root_path
     within(recently_released) do
       assert_text @album.title
     end

--- a/test/system/reordering_tracklist_test.rb
+++ b/test/system/reordering_tracklist_test.rb
@@ -12,7 +12,7 @@ class ReorderingTracklistTest < ApplicationSystemTestCase
     first_track = @track
     second_track = create(:track, album: first_track.album, title: 'Second Track')
 
-    visit artist_album_url(first_track.artist, first_track.album)
+    visit artist_album_path(first_track.artist, first_track.album)
 
     assert_text "1. #{first_track.title}"
     assert_text "2. #{second_track.title}"

--- a/test/system/sessions_test.rb
+++ b/test/system/sessions_test.rb
@@ -8,7 +8,7 @@ class SessionsTest < ApplicationSystemTestCase
   end
 
   test 'logging in' do
-    visit log_in_url
+    visit log_in_path
     fill_in 'Email', with: @user.email
     fill_in 'Password', with: 'Secret1*3*5*'
     click_on 'Log in'

--- a/test/system/signing_up_test.rb
+++ b/test/system/signing_up_test.rb
@@ -4,7 +4,7 @@ require 'application_system_test_case'
 
 class SigningUpTest < ApplicationSystemTestCase
   test 'signing up' do
-    visit root_url
+    visit root_path
     click_on 'sign up'
     fill_in 'Email', with: 'user@example.com'
     fill_in 'Password', with: 'Secret1*3*5*'

--- a/test/system/tagging_an_album_test.rb
+++ b/test/system/tagging_an_album_test.rb
@@ -14,7 +14,7 @@ class TaggingAnAlbumTest < ApplicationSystemTestCase
 
   # test 'creating an album' do
   #   log_in_as(@artist_user)
-  #   visit edit_artist_album_url(@artist, @album)
+  #   visit edit_artist_album_path(@artist, @album)
 
   #   select 'jazz', from: 'Tags'
   #   select 'folk', from: 'Tags'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ module ActiveSupport
     # parallelize(workers: :number_of_processors)
 
     def log_in_as(user)
-      post(log_in_url, params: { email: user.email, password: 'Secret1*3*5*' })
+      post(log_in_path, params: { email: user.email, password: 'Secret1*3*5*' })
       user
     end
   end


### PR DESCRIPTION
I think it's more idiomatic to use the `*_path` route helper methods unless we specifically need an absolute URL, e.g. in Stripe checkout callbacks, links in email templates, atom feeds, etc.

I'm also hoping it's going to make it easier to reason about some problems I've been having with system tests when setting `default_url_options`.