### PR TITLE
Fix CDN URLs in system tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -34,5 +34,5 @@ Rails.application.configure do
   end
 
   config.base_url = 'http://example.com'
-  config.cdn_base_url = config.base_url
+  config.cdn_base_url = nil
 end

--- a/config/initializers/url_options.rb
+++ b/config/initializers/url_options.rb
@@ -8,10 +8,14 @@ Rails.application.default_url_options = {
   port: base_uri.port
 }
 
-cdn_base_uri = URI.parse(Rails.configuration.cdn_base_url)
+if Rails.configuration.cdn_base_url.present?
+  cdn_base_uri = URI.parse(Rails.configuration.cdn_base_url)
 
-Rails.configuration.cdn_url_options = {
-  protocol: cdn_base_uri.scheme,
-  host: cdn_base_uri.host,
-  port: cdn_base_uri.port
-}
+  Rails.configuration.cdn_url_options = {
+    protocol: cdn_base_uri.scheme,
+    host: cdn_base_uri.host,
+    port: cdn_base_uri.port
+  }
+else
+  Rails.configuration.cdn_url_options = {}
+end


### PR DESCRIPTION
It turns out that my note in [this commit note][1] was incorrect!

After that commit, CDN URLs had their host set to 'example.com' which meant that ActiveStorage attachments were not rendered in system tests and we've seen some instances of system test failing because: "there are still pending connections" to example.com.

However, this has highlighted a problem that has existed since the `cdn_url` route helper was introduced. Prior to aforementioned commit above, CDN URLs had their host and port set to 'localhost:3000'. While this works fine in development, it didn't work in the system tests, because Capybara runs the app on localhost with a random port. This meant that ActiveStorage attachments were not rendered in system tests. I'm guessing that we saw fewer (no?) system test failures because at least the host was local to the machine.

Anyway, the way to fix this properly is not to set any CDN URL options for CDN URL routes in the test environment. This means the URLs are all relative and thus work OK with the host and port used by Capybara.

[1]: https://github.com/freerange/jam-coop/commit/6c033d88c30de05e488f3869754e6bb7536a4850