### PR TITLE
Slack notification for CI build pass or fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
     needs:
       - linters
       - tests
-    if: ${{ always() }}
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
     steps:
       - name: Slack notification
         uses: justinr636/github-action-slack-notify-build@v1


### PR DESCRIPTION
We should now get notifications like the one below in the `#jam-github-notifications` Slack channel whenever a CI build passes or fails on the `main` branch.

<img width="1318" height="394" alt="CleanShot 2025-11-14 at 14 15 11@2x" src="https://github.com/user-attachments/assets/0d2c420f-10e7-402d-8d11-39818e501519" />
