### PR TITLE
Remove original_data from tracks in schema.rb

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -306,7 +306,6 @@ ActiveRecord::Schema[8.1].define(version: 2025_11_26_095844) do
   create_table "tracks", force: :cascade do |t|
     t.bigint "album_id"
     t.datetime "created_at", null: false
-    t.text "original_data"
     t.integer "position"
     t.string "title"
     t.datetime "updated_at", null: false


### PR DESCRIPTION
As far as I can tell this isn't used as it's not present in the schema in the production database (I noticed it when downloading the production data to use locally). My hunch is that Lowis has/had this extra column in his development database and so it was ending up in schema.rb after a `rails db:schema:dump`.

History:

- Added in 959929c57405aafef33e9dea2628b15c2d7f628b on 25th Sep 2023
- Removed in eeb2c74aa48389d67dcf1a33418182ec9fa1473e on 13th Nov 2023
- Added in 5d3ce25bce3153e4783a36678ec2fff13bcae2d9 on 13th Nov 2023