### PR TITLE
Allow users to add a catalogue number to a Release

### DIFF
--- a/app/controllers/admin/releases_controller.rb
+++ b/app/controllers/admin/releases_controller.rb
@@ -46,7 +46,7 @@ module Admin
     end
 
     def release_params
-      params.expect(release: %i[label album_id])
+      params.expect(release: %i[label album_id catalogue_number])
     end
 
     def authorize_label

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -14,6 +14,8 @@ class Album < ApplicationRecord
   has_many :tags, -> { order :name }, through: :taggings
   has_one_attached :cover
   belongs_to :license
+  has_many :releases, dependent: :destroy
+  has_many :labels, through: :releases
 
   accepts_nested_attributes_for :tracks, reject_if: :all_blank, allow_destroy: true
 

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -3,4 +3,6 @@
 class Release < ApplicationRecord
   belongs_to :album
   belongs_to :label
+
+  validates :catalogue_number, length: { maximum: 12 }, allow_blank: true
 end

--- a/app/views/admin/releases/_form.html.erb
+++ b/app/views/admin/releases/_form.html.erb
@@ -1,6 +1,10 @@
 <%= form_for([:admin, label, release], builder: TailwindFormBuilder) do |form| %>
   <%= render ModelErrorComponent.new(model: release) %>
-  <%= form.select :album_id, Album.releaseable_on(@label).or(Album.where(id: release.album_id)).pluck(:title, :id).uniq, { label: { text: 'Album' }, class: 'w-full' } %>
+
+  <%= form.select :album_id, Album.releaseable_on(@label).or(Album.where(id: release.album_id)).pluck(:title, :id).uniq, { label: { text: 'Album' }, class: 'w-full mb-3' } %>
+
+  <%= form.text_field :catalogue_number, { label: { text: 'Catalogue number (optional)' }, placeholder: 'e.g. jam-123', class: 'w-full' } %>
+
   <div class='flex flex-row justify-end gap-3 mt-3'>
     <% if release.persisted? %>
       <%= form.button 'Remove release', type: :submit, formmethod: :delete, data: { turbo_confirm: 'Are you sure you want to remove this release?' }, class: 'border border-red-600 hover:bg-red-300 font-medium py-3 px-5 w-full sm:w-auto' %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -149,6 +149,9 @@
       <p><strong>Released:</strong> <%= @album.released_on.strftime('%B %-d, %Y') %></p>
     <% end %>
 
+    <% if @album.releases.first&.catalogue_number.present? %>
+      <p><strong>Label:</strong> <%= link_to(@album.releases.first.label.name, label_path(@album.releases.first.label), class: 'underline') %> (<%= @album.releases.first.catalogue_number %>)</p>
+    <% end %>
     <% if @album.license.source %>
       <p><strong>License:</strong> <%= link_to @album.license.label, @album.license.source, class: 'underline' %></p>
     <% else %>

--- a/db/migrate/20251218101316_add_catalogue_number_to_releases.rb
+++ b/db/migrate/20251218101316_add_catalogue_number_to_releases.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCatalogueNumberToReleases < ActiveRecord::Migration[8.1]
+  def change
+    add_column :releases, :catalogue_number, :string, limit: 12
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_05_114214) do
+ActiveRecord::Schema[8.1].define(version: 2025_12_18_101316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -165,6 +165,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_05_114214) do
 
   create_table "releases", force: :cascade do |t|
     t.bigint "album_id", null: false
+    t.string "catalogue_number", limit: 12
     t.datetime "created_at", null: false
     t.bigint "label_id", null: false
     t.datetime "updated_at", null: false

--- a/test/system/administering_a_label_test.rb
+++ b/test/system/administering_a_label_test.rb
@@ -33,19 +33,24 @@ class AdministeringALabelTest < ApplicationSystemTestCase
 
   test 'adding a release to a label' do
     artist = create(:artist, user: @user)
-    create(:published_album, artist:, title: 'album-name')
+    album = create(:published_album, artist:, title: 'album-name')
     label = create(:label, user: @user)
 
     visit account_path
     click_on label.name
     click_on 'Add release'
     select 'album-name', from: 'Album'
+    fill_in 'Catalogue number', with: 'jam-123'
     click_on 'Save release'
 
     within(release_section) do
       assert_text 'album-name'
       assert_text artist.name
     end
+
+    visit artist_album_path(artist, album)
+    assert_text 'album-name'
+    assert_text 'jam-123'
   end
 
   test 'editing an existing release' do


### PR DESCRIPTION
This commit allows users to add an optional catalogue number to a release. We're only surfacing the number on the Album show page for now, but this feature was suggested by one of our label beta-testers who said it helps keep data consistent between various systems they use.

The 12 character limit on catalogue numbers seems generous enough given the catalogue numbers used in the wild[1].

[1] e.g. https://en.wikipedia.org/wiki/Catalog_number_(music)