### PR TITLE
Run development postgres inside docker

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,6 +17,8 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: 127.0.0.1
+
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+---
+services:
+  postgres:
+    image: postgres:14-alpine
+    volumes:
+      - postgresql:/var/lib/postgresql/data:delegated
+      - ./docker-postgres-init.sh:/docker-entrypoint-initdb.d/init.sh
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      CURRENT_USER: ${USER}
+      POSTGRES_HOST_AUTH_METHOD: trust
+volumes:
+  postgresql:
+  storage:

--- a/docker-postgres-init.sh
+++ b/docker-postgres-init.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "postgres" <<-EOSQL
+    CREATE USER "$CURRENT_USER" SUPERUSER;
+EOSQL


### PR DESCRIPTION
I've recently started using linux for development, and it seems like a relatively straightforward way of running multiple versions of postgres on the same machine (where I'd previously use homebrew on OS X) is to run them inside a docker container.

Running the rest of the rails app on the system has some advantages. I followed a tutorial[1] to get this working, but it's required making a couple of changes to config/database.yml. Changing the host to an explicit `127.0.0.1` from `localhost` shouldn't cause issues for other developers, but having a specific username (`jam` here) rather than defaulting to `$USER` might.

[1] https://www.codewithjason.com/dockerize-rails-apps-database/