### PR TITLE
Allow users to connect a Stripe account to receive payouts

### DIFF
--- a/app/components/model_error_component.rb
+++ b/app/components/model_error_component.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class ModelErrorComponent < ViewComponent::Base
-  def initialize(model:)
+  def initialize(model:, model_name: nil)
     @model = model
+    @model_name = model_name || model.model_name.human.downcase
   end
 
   def render?

--- a/app/components/model_error_component/model_error_component.html.erb
+++ b/app/components/model_error_component/model_error_component.html.erb
@@ -1,5 +1,5 @@
 <%= render(ErrorBoxComponent.new(
-  title: "#{pluralize(@model.errors.count, "error")} prohibited this #{@model.model_name.human.downcase} from being saved"
+  title: "#{pluralize(@model.errors.count, "error")} prohibited this #{@model_name} from being saved"
 )) do %>
   <ul>
     <% @model.errors.each do |error| %>

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -50,6 +50,6 @@ class PurchasesController < ApplicationController
   end
 
   def stripe_connect_account
-    StripeConnectAccount.find_or_initialize_by(user: artist.user)
+    artist.user.stripe_connect_account || StripeConnectAccount.new
   end
 end

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -21,7 +21,7 @@ class PurchasesController < ApplicationController
     )
 
     if @purchase.save
-      resp = StripeService.new(@purchase).create_checkout_session
+      resp = StripeService.new(@purchase, stripe_connect_account).create_checkout_session
 
       if resp.success?
         @purchase.update!(stripe_session_id: resp.id)
@@ -42,10 +42,14 @@ class PurchasesController < ApplicationController
   end
 
   def artist
-    Artist.friendly.find(params[:artist_id])
+    Artist.includes(:user).friendly.find(params[:artist_id])
   end
 
   def purchase_params
     params.expect(purchase: %i[price contact_opt_in])
+  end
+
+  def stripe_connect_account
+    StripeConnectAccount.find_or_initialize_by(user: artist.user)
   end
 end

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+class StripeConnectAccountsController < ApplicationController
+  before_action :set_user
+  before_action :set_stripe_connect_account, except: %i[create]
+
+  def create
+    authorize StripeConnectAccount
+
+    account = Stripe::Account.create(create_params)
+    StripeConnectAccount.create!(user: @user, stripe_identifier: account.id)
+
+    redirect_to link_stripe_connect_account_path(account.id)
+  end
+
+  def link
+    authorize @stripe_connect_account
+
+    account_link = Stripe::AccountLink.create(link_params)
+    redirect_to account_link.url, allow_other_host: true
+  end
+
+  def success
+    authorize @stripe_connect_account
+
+    resp = Stripe::Account.retrieve(@stripe_connect_account.stripe_identifier)
+    @stripe_connect_account.update!(
+      details_submitted: resp.details_submitted?,
+      charges_enabled: resp.charges_enabled?
+    )
+
+    redirect_to account_path
+  end
+
+  private
+
+  def account_id
+    params[:id]
+  end
+
+  def create_params
+    {}
+  end
+
+  def link_params
+    {
+      account: account_id,
+      refresh_url: link_stripe_connect_account_url(account_id),
+      return_url: success_stripe_connect_account_url(account_id),
+      type: 'account_onboarding'
+    }
+  end
+
+  def set_user
+    @user = Current.user
+  end
+
+  def set_stripe_connect_account
+    @stripe_connect_account = StripeConnectAccount.find_by!(
+      user: @user,
+      stripe_identifier: account_id
+    )
+  end
+end

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -36,7 +36,9 @@ class StripeConnectAccountsController < ApplicationController
   end
 
   def create_params
-    {}
+    {
+      email: @user.email
+    }
   end
 
   def link_params

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -26,7 +26,8 @@ class StripeConnectAccountsController < ApplicationController
     resp = Stripe::Account.retrieve(@stripe_connect_account.stripe_identifier)
     @stripe_connect_account.update!(
       details_submitted: resp.details_submitted?,
-      charges_enabled: resp.charges_enabled?
+      charges_enabled: resp.charges_enabled?,
+      payouts_enabled: resp.payouts_enabled?
     )
 
     redirect_to account_path

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -24,11 +24,7 @@ class StripeConnectAccountsController < ApplicationController
     authorize @stripe_connect_account
 
     resp = Stripe::Account.retrieve(@stripe_connect_account.stripe_identifier)
-    @stripe_connect_account.update!(
-      details_submitted: resp.details_submitted?,
-      charges_enabled: resp.charges_enabled?,
-      payouts_enabled: resp.payouts_enabled?
-    )
+    @stripe_connect_account.sync_from!(resp)
 
     redirect_to account_path
   end

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -12,6 +12,9 @@ class StripeConnectAccountsController < ApplicationController
     @user.create_stripe_connect_account!(stripe_identifier: account.id)
 
     redirect_to link_stripe_connect_account_path(account.id)
+  rescue Stripe::StripeError => e
+    Rollbar.error(e)
+    redirect_to account_path, alert: 'Error creating Stripe Connect account'
   end
 
   def link

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -8,13 +8,19 @@ class StripeConnectAccountsController < ApplicationController
   def create
     authorize StripeConnectAccount
 
-    account = Stripe::Account.create(create_params)
-    @user.create_stripe_connect_account(
-      **stripe_connect_account_params,
-      stripe_identifier: account.id
+    account_in_jam = @user.build_stripe_connect_account(
+      stripe_connect_account_params
     )
+    if account_in_jam.valid?
+      account_in_stripe = Stripe::Account.create(create_params)
+      account_in_jam.stripe_identifier = account_in_stripe.id
+      account_in_jam.save!
 
-    redirect_to link_stripe_connect_account_path(account.id)
+      redirect_to link_stripe_connect_account_path(account_in_stripe.id)
+    else
+      flash.now[:alert] = 'Stripe Connect account is invalid'
+      render 'users/show', status: :unprocessable_content
+    end
   rescue Stripe::StripeError => e
     Rollbar.error(e)
     redirect_to account_path, alert: 'Error creating Stripe Connect account'

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -2,6 +2,7 @@
 
 class StripeConnectAccountsController < ApplicationController
   before_action :set_user
+  before_action :ensure_stripe_connect_available
   before_action :set_stripe_connect_account, except: %i[create]
 
   def create
@@ -52,6 +53,12 @@ class StripeConnectAccountsController < ApplicationController
 
   def set_user
     @user = Current.user
+  end
+
+  def ensure_stripe_connect_available
+    return if @user.stripe_connect_enabled?
+
+    redirect_to account_path, alert: 'Stripe Connect is not available'
   end
 
   def set_stripe_connect_account

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -9,7 +9,10 @@ class StripeConnectAccountsController < ApplicationController
     authorize StripeConnectAccount
 
     account = Stripe::Account.create(create_params)
-    @user.create_stripe_connect_account(stripe_identifier: account.id)
+    @user.create_stripe_connect_account(
+      **stripe_connect_account_params,
+      stripe_identifier: account.id
+    )
 
     redirect_to link_stripe_connect_account_path(account.id)
   rescue Stripe::StripeError => e
@@ -39,9 +42,14 @@ class StripeConnectAccountsController < ApplicationController
     params[:id]
   end
 
+  def stripe_connect_account_params
+    params.expect(stripe_connect_account: [:country_code])
+  end
+
   def create_params
     {
-      email: @user.email
+      email: @user.email,
+      country: stripe_connect_account_params[:country_code]
     }
   end
 

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -9,7 +9,7 @@ class StripeConnectAccountsController < ApplicationController
     authorize StripeConnectAccount
 
     account = Stripe::Account.create(create_params)
-    StripeConnectAccount.create!(user: @user, stripe_identifier: account.id)
+    @user.create_stripe_connect_account!(stripe_identifier: account.id)
 
     redirect_to link_stripe_connect_account_path(account.id)
   end
@@ -62,9 +62,9 @@ class StripeConnectAccountsController < ApplicationController
   end
 
   def set_stripe_connect_account
-    @stripe_connect_account = StripeConnectAccount.find_by!(
-      user: @user,
-      stripe_identifier: account_id
-    )
+    @stripe_connect_account = @user.stripe_connect_account
+    return if @stripe_connect_account.stripe_identifier == account_id
+
+    raise ActiveRecord::RecordNotFound, 'StripeConnectAccount not found'
   end
 end

--- a/app/controllers/stripe_connect_accounts_controller.rb
+++ b/app/controllers/stripe_connect_accounts_controller.rb
@@ -9,7 +9,7 @@ class StripeConnectAccountsController < ApplicationController
     authorize StripeConnectAccount
 
     account = Stripe::Account.create(create_params)
-    @user.create_stripe_connect_account!(stripe_identifier: account.id)
+    @user.create_stripe_connect_account(stripe_identifier: account.id)
 
     redirect_to link_stripe_connect_account_path(account.id)
   rescue Stripe::StripeError => e

--- a/app/controllers/stripe_webhook_events_controller.rb
+++ b/app/controllers/stripe_webhook_events_controller.rb
@@ -28,6 +28,13 @@ class StripeWebhookEventsController < ApplicationController
     when 'checkout.session.completed'
       stripe_session_id = event.data.object.id
       PurchaseCompleteJob.perform_later(stripe_session_id)
+    when 'account.updated'
+      account_in_stripe = event.data.object
+      account_in_jam = StripeConnectAccount.find_by!(stripe_identifier: account_in_stripe.id)
+      account_in_jam.update!(
+        details_submitted: account_in_stripe.details_submitted?,
+        charges_enabled: account_in_stripe.charges_enabled?
+      )
     else
       Rails.logger.debug { "Unhandled event type: #{event.type}" }
     end

--- a/app/controllers/stripe_webhook_events_controller.rb
+++ b/app/controllers/stripe_webhook_events_controller.rb
@@ -31,11 +31,7 @@ class StripeWebhookEventsController < ApplicationController
     when 'account.updated'
       account_in_stripe = event.data.object
       account_in_jam = StripeConnectAccount.find_by!(stripe_identifier: account_in_stripe.id)
-      account_in_jam.update!(
-        details_submitted: account_in_stripe.details_submitted?,
-        charges_enabled: account_in_stripe.charges_enabled?,
-        payouts_enabled: account_in_stripe.payouts_enabled?
-      )
+      account_in_jam.sync_from!(account_in_stripe)
     else
       Rails.logger.debug { "Unhandled event type: #{event.type}" }
     end

--- a/app/controllers/stripe_webhook_events_controller.rb
+++ b/app/controllers/stripe_webhook_events_controller.rb
@@ -33,7 +33,8 @@ class StripeWebhookEventsController < ApplicationController
       account_in_jam = StripeConnectAccount.find_by!(stripe_identifier: account_in_stripe.id)
       account_in_jam.update!(
         details_submitted: account_in_stripe.details_submitted?,
-        charges_enabled: account_in_stripe.charges_enabled?
+        charges_enabled: account_in_stripe.charges_enabled?,
+        payouts_enabled: account_in_stripe.payouts_enabled?
       )
     else
       Rails.logger.debug { "Unhandled event type: #{event.type}" }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,6 +28,6 @@ class UsersController < ApplicationController
   end
 
   def set_stripe_account
-    @stripe_account = StripeConnectAccount.find_by(user: @user)
+    @stripe_account = @user.stripe_connect_account
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user, :set_stripe_account
+  before_action :set_user
 
   def show
     authorize @user
@@ -25,9 +25,5 @@ class UsersController < ApplicationController
 
   def user_params
     params.expect(user: [:opt_in_to_newsletter])
-  end
-
-  def set_stripe_account
-    @stripe_account = @user.stripe_connect_account
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  before_action :set_user
+  before_action :set_user, :set_stripe_account
 
   def show
     authorize @user
@@ -25,5 +25,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.expect(user: [:opt_in_to_newsletter])
+  end
+
+  def set_stripe_account
+    @stripe_account = StripeConnectAccount.find_by(user: @user)
   end
 end

--- a/app/helpers/stripe_connect_account_helper.rb
+++ b/app/helpers/stripe_connect_account_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module StripeConnectAccountHelper
+  def options_for_stripe_connect_country_select
+    [['🇬🇧 United Kingdom (GBP)', 'GB']]
+  end
+
+  def stripe_connect_country_text_from_country_code(country_code)
+    options_for_stripe_connect_country_select.find { |_, cc| cc == country_code }&.first
+  end
+end

--- a/app/jobs/purchase_complete_job.rb
+++ b/app/jobs/purchase_complete_job.rb
@@ -16,8 +16,7 @@ class PurchaseCompleteJob < ApplicationJob
 
     payment_intent = Stripe::PaymentIntent.retrieve(stripe_session.payment_intent)
     if payment_intent.transfer_data.present?
-      seller = purchase.album.artist.user
-      payout = seller.payouts.create!(
+      payout = purchase.seller.payouts.create!(
         payout_type: Payout::STRIPE_TYPE,
         transaction_reference: payment_intent.id,
         destination_reference: payment_intent.transfer_data.destination,

--- a/app/jobs/purchase_complete_job.rb
+++ b/app/jobs/purchase_complete_job.rb
@@ -13,6 +13,20 @@ class PurchaseCompleteJob < ApplicationJob
     purchase.update(user: User.find_by(email: customer_email)) unless purchase.user
 
     PurchaseMailer.with(purchase:).completed.deliver_later
+
+    payment_intent = Stripe::PaymentIntent.retrieve(stripe_session.payment_intent)
+    if payment_intent.transfer_data.present?
+      seller = purchase.album.artist.user
+      payout = seller.payouts.create!(
+        payout_type: Payout::STRIPE_TYPE,
+        transaction_reference: payment_intent.id,
+        destination_reference: payment_intent.transfer_data.destination,
+        amount_in_pence: payment_intent.transfer_data.amount,
+        platform_fee_in_pence: payment_intent.metadata.application_fee_amount
+      )
+      purchase.update!(payout:)
+    end
+
     PurchaseMailer.with(purchase:).notify_artist.deliver_later
   end
 end

--- a/app/lib/purchase_exporter.rb
+++ b/app/lib/purchase_exporter.rb
@@ -17,9 +17,9 @@ class PurchaseExporter
           purchase.id,
           (purchase.price * 100).to_i,
           purchase.amount_tax,
-          purchase.album.artist.user.email,
-          purchase.album.artist.user.payout_detail&.name,
-          purchase.album.artist.user.payout_detail&.country,
+          purchase.seller.email,
+          purchase.seller.payout_detail&.name,
+          purchase.seller.payout_detail&.country,
           purchase.album.title,
           purchase.album.artist.name
         ]

--- a/app/lib/purchase_exporter.rb
+++ b/app/lib/purchase_exporter.rb
@@ -30,6 +30,9 @@ class PurchaseExporter
   private
 
   def purchases
-    Purchase.where(created_at: @date.last_month.beginning_of_month...@date.beginning_of_month).where(completed: true)
+    Purchase
+      .where(created_at: @date.last_month.beginning_of_month...@date.beginning_of_month)
+      .where(completed: true)
+      .without_payout
   end
 end

--- a/app/mailers/purchase_mailer.rb
+++ b/app/mailers/purchase_mailer.rb
@@ -12,7 +12,7 @@ class PurchaseMailer < ApplicationMailer
   def notify_artist
     @purchase = params[:purchase]
 
-    return unless (@user = @purchase.album.artist.user)
+    return unless (@user = @purchase.seller)
     return if @user.suppress_sending?
 
     @stripe_account = @user.stripe_connect_account

--- a/app/mailers/purchase_mailer.rb
+++ b/app/mailers/purchase_mailer.rb
@@ -12,11 +12,11 @@ class PurchaseMailer < ApplicationMailer
   def notify_artist
     @purchase = params[:purchase]
 
-    return unless (@user = @purchase.seller)
-    return if @user.suppress_sending?
+    return unless (@seller = @purchase.seller)
+    return if @seller.suppress_sending?
 
-    @stripe_account = @user.stripe_connect_account
+    @stripe_account = @seller.stripe_connect_account
 
-    mail to: @user.email, subject: "You have sold a copy of #{@purchase.album.title}"
+    mail to: @seller.email, subject: "You have sold a copy of #{@purchase.album.title}"
   end
 end

--- a/app/mailers/purchase_mailer.rb
+++ b/app/mailers/purchase_mailer.rb
@@ -15,6 +15,8 @@ class PurchaseMailer < ApplicationMailer
     return unless (@user = @purchase.album.artist.user)
     return if @user.suppress_sending?
 
+    @stripe_account = @user.stripe_connect_account
+
     mail to: @user.email, subject: "You have sold a copy of #{@purchase.album.title}"
   end
 end

--- a/app/mailers/stripe_connect_account_mailer.rb
+++ b/app/mailers/stripe_connect_account_mailer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class StripeConnectAccountMailer < ApplicationMailer
+  def charges_enabled
+    @account = params[:account]
+
+    seller = @account.user
+    return if seller.suppress_sending?
+
+    mail to: seller.email, subject: 'Your Stripe account now accepts payments'
+  end
+
+  def payouts_enabled
+    @account = params[:account]
+
+    seller = @account.user
+    return if seller.suppress_sending?
+
+    mail to: seller.email, subject: 'Your Stripe account now allows payouts'
+  end
+end

--- a/app/models/payout.rb
+++ b/app/models/payout.rb
@@ -19,4 +19,8 @@ class Payout < ApplicationRecord
   def amount
     amount_in_pence / 100.0
   end
+
+  def platform_fee
+    platform_fee_in_pence / 100.0
+  end
 end

--- a/app/models/payout.rb
+++ b/app/models/payout.rb
@@ -15,4 +15,8 @@ class Payout < ApplicationRecord
   def stripe?
     payout_type == STRIPE_TYPE
   end
+
+  def amount
+    amount_in_pence / 100.0
+  end
 end

--- a/app/models/payout.rb
+++ b/app/models/payout.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Payout < ApplicationRecord
+  belongs_to :user
+
+  validates :payout_type, presence: true
+  validates :transaction_reference, presence: true
+  validates :destination_reference, presence: true
+  validates :amount_in_pence, presence: true
+  validates :platform_fee_in_pence, presence: true
+end

--- a/app/models/payout.rb
+++ b/app/models/payout.rb
@@ -2,6 +2,7 @@
 
 class Payout < ApplicationRecord
   belongs_to :user
+  has_many :purchases, dependent: :nullify
 
   validates :payout_type, presence: true
   validates :transaction_reference, presence: true

--- a/app/models/payout.rb
+++ b/app/models/payout.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Payout < ApplicationRecord
+  STRIPE_TYPE = 'stripe'
+
   belongs_to :user
   has_many :purchases, dependent: :nullify
 
@@ -9,4 +11,8 @@ class Payout < ApplicationRecord
   validates :destination_reference, presence: true
   validates :amount_in_pence, presence: true
   validates :platform_fee_in_pence, presence: true
+
+  def stripe?
+    payout_type == STRIPE_TYPE
+  end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -8,6 +8,9 @@ class Purchase < ApplicationRecord
   belongs_to :payout, optional: true
   has_many :purchase_downloads, dependent: :destroy
 
+  has_one :artist, through: :album
+  has_one :seller, through: :artist, source: :user, class_name: 'User'
+
   validates :price, presence: true, numericality: true
   validate :price_is_greater_than_album_price, unless: -> { price.blank? }
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -5,6 +5,7 @@ class Purchase < ApplicationRecord
 
   belongs_to :album
   belongs_to :user, optional: true
+  belongs_to :payout, optional: true
   has_many :purchase_downloads, dependent: :destroy
 
   validates :price, presence: true, numericality: true

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -15,6 +15,10 @@ class Purchase < ApplicationRecord
 
   scope :without_payout, -> { where(payout_id: nil) }
 
+  def stripe_payout
+    payout&.stripe? ? payout : nil
+  end
+
   def price_in_pence
     (price * 100).to_i
   end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -13,6 +13,8 @@ class Purchase < ApplicationRecord
 
   after_commit :create_purchase_downloads, on: :create
 
+  scope :without_payout, -> { where(payout_id: nil) }
+
   def price_in_pence
     (price * 100).to_i
   end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -32,6 +32,10 @@ class Purchase < ApplicationRecord
     sending_suppressed_at.present?
   end
 
+  def platform_fee_in_pence
+    (price_in_pence * platform_fee_fraction).to_i
+  end
+
   private
 
   def price_is_greater_than_album_price
@@ -43,5 +47,9 @@ class Purchase < ApplicationRecord
   def create_purchase_downloads
     ZipDownloadJob.perform_later(self, format: :mp3v0)
     ZipDownloadJob.perform_later(self, format: :flac)
+  end
+
+  def platform_fee_fraction
+    Rails.configuration.platform_fee_percentage / 100.0
   end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -12,6 +12,10 @@ class Purchase < ApplicationRecord
 
   after_commit :create_purchase_downloads, on: :create
 
+  def price_in_pence
+    (price * 100).to_i
+  end
+
   def price_excluding_gratuity_in_pence
     (album.price * 100).to_i
   end

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -14,4 +14,8 @@ class StripeConnectAccount < ApplicationRecord
       'not_started'
     end
   end
+
+  def accepts_payments?
+    charges_enabled?
+  end
 end

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class StripeConnectAccount < ApplicationRecord
+  belongs_to :user
+
+  validates :stripe_identifier, presence: true
+end

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -4,4 +4,14 @@ class StripeConnectAccount < ApplicationRecord
   belongs_to :user
 
   validates :stripe_identifier, presence: true
+
+  def status
+    if charges_enabled?
+      'charges_enabled'
+    elsif details_submitted?
+      'details_submitted'
+    else
+      'not_started'
+    end
+  end
 end

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -5,6 +5,14 @@ class StripeConnectAccount < ApplicationRecord
 
   validates :stripe_identifier, presence: true
 
+  def sync_from!(stripe_account)
+    update!(
+      details_submitted: stripe_account.details_submitted?,
+      charges_enabled: stripe_account.charges_enabled?,
+      payouts_enabled: stripe_account.payouts_enabled?
+    )
+  end
+
   def status
     if charges_enabled?
       'charges_enabled'

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -3,6 +3,8 @@
 class StripeConnectAccount < ApplicationRecord
   belongs_to :user
 
+  validates :country_code, presence: true
+
   def sync_from!(stripe_account)
     update!(
       details_submitted: stripe_account.details_submitted?,

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -3,7 +3,7 @@
 class StripeConnectAccount < ApplicationRecord
   belongs_to :user
 
-  validates :country_code, presence: true
+  validates :country_code, presence: true, inclusion: { in: ['GB'], message: 'is not supported', allow_blank: true }
 
   def sync_from!(stripe_account)
     update!(

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -11,16 +11,6 @@ class StripeConnectAccount < ApplicationRecord
     )
   end
 
-  def status
-    if charges_enabled?
-      'charges_enabled'
-    elsif details_submitted?
-      'details_submitted'
-    else
-      'not_started'
-    end
-  end
-
   def accepts_payments?
     charges_enabled?
   end

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -3,8 +3,6 @@
 class StripeConnectAccount < ApplicationRecord
   belongs_to :user
 
-  validates :stripe_identifier, presence: true
-
   def sync_from!(stripe_account)
     update!(
       details_submitted: stripe_account.details_submitted?,

--- a/app/models/stripe_connect_account.rb
+++ b/app/models/stripe_connect_account.rb
@@ -11,9 +11,15 @@ class StripeConnectAccount < ApplicationRecord
       charges_enabled: stripe_account.charges_enabled?,
       payouts_enabled: stripe_account.payouts_enabled?
     )
+    mailer.charges_enabled.deliver_later if charges_enabled? && charges_enabled_previously_changed?
+    mailer.payouts_enabled.deliver_later if payouts_enabled? && payouts_enabled_previously_changed?
   end
 
   def accepts_payments?
     charges_enabled?
+  end
+
+  def mailer
+    StripeConnectAccountMailer.with(account: self)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :followed_artists, through: :followings, source: :artist
   has_many :labels, dependent: :destroy
   has_one :payout_detail, dependent: :destroy
+  has_one :stripe_connect_account, dependent: :destroy
 
   validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
   validates :password, allow_nil: true, length: { minimum: 12 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :followings, dependent: :destroy
   has_many :followed_artists, through: :followings, source: :artist
   has_many :labels, dependent: :destroy
+  has_many :payouts, dependent: :destroy
   has_one :payout_detail, dependent: :destroy
   has_one :stripe_connect_account, dependent: :destroy
 

--- a/app/policies/stripe_connect_account_policy.rb
+++ b/app/policies/stripe_connect_account_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class StripeConnectAccountPolicy < ApplicationPolicy
+  def new?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def edit?
+    true
+  end
+
+  def update?
+    true
+  end
+
+  def link?
+    true
+  end
+
+  def success?
+    true
+  end
+end

--- a/app/services/stripe_service.rb
+++ b/app/services/stripe_service.rb
@@ -42,7 +42,7 @@ class StripeService
   end
 
   def create_checkout_session
-    session = Stripe::Checkout::Session.create(checkout_params, checkout_options)
+    session = Stripe::Checkout::Session.create(checkout_params)
 
     StripeServiceResponse.new(
       status: 'ok',
@@ -81,12 +81,14 @@ class StripeService
   def payment_intent_data
     return {} unless @stripe_connect_account.accepts_payments?
 
-    { application_fee_amount: @purchase.platform_fee_in_pence }
-  end
-
-  def checkout_options
-    return {} unless @stripe_connect_account.accepts_payments?
-
-    { stripe_account: @stripe_connect_account.stripe_identifier }
+    {
+      metadata: {
+        application_fee_amount: @purchase.platform_fee_in_pence
+      },
+      transfer_data: {
+        destination: @stripe_connect_account.stripe_identifier,
+        amount: @purchase.price_in_pence - @purchase.platform_fee_in_pence
+      }
+    }
   end
 end

--- a/app/views/purchase_mailer/notify_artist.html.erb
+++ b/app/views/purchase_mailer/notify_artist.html.erb
@@ -4,21 +4,23 @@
   for <%= number_to_currency(@purchase.price, unit: "£") %>.</p>
 
 <p>
-  <% if @stripe_account %>
-    <% if @stripe_account.accepts_payments? %>
-      A payment has been made to your
-      <%= link_to "Stripe account", link_stripe_connect_account_url(@stripe_account.stripe_identifier) %>.
-    <% else %>
+  <% if @purchase.stripe_payout %>
+    A payment of <%= number_to_currency(@purchase.stripe_payout.amount, unit: "£") %> has been made to your
+    <%= link_to "Stripe account", link_stripe_connect_account_url(@stripe_account.stripe_identifier) %>.
+    A platform fee of <%= number_to_currency(@purchase.stripe_payout.platform_fee, unit: "£") %> was deducted.
+    Other Stripe fees may have been incurred (e.g. currency conversion fees).
+  <% else %>
+    <% if @stripe_account && !@stripe_account.accepts_payments? %>
       You've started connecting a
       <%= link_to "Stripe account", link_stripe_connect_account_url(@stripe_account.stripe_identifier) %>,
       but it's not yet ready to receive payments.
-    <% end %>
-  <% else %>
-    <% if @user.payout_detail %>
-      You have already provided your payout details. If you need to, you can <%= link_to 'change them', account_url %>.
     <% else %>
-      <b>Important:</b> we need to know <%= link_to 'some details', account_url %> before we can make a
-      payment to you.
+      <% if @user.payout_detail %>
+        You have already provided your payout details. If you need to, you can <%= link_to 'change them', account_url %>.
+      <% else %>
+        <b>Important:</b> we need to know <%= link_to 'some details', account_url %> before we can make a
+        payment to you.
+      <% end %>
     <% end %>
   <% end %>
 </p>

--- a/app/views/purchase_mailer/notify_artist.html.erb
+++ b/app/views/purchase_mailer/notify_artist.html.erb
@@ -15,7 +15,7 @@
       <%= link_to "Stripe account", link_stripe_connect_account_url(@stripe_account.stripe_identifier) %>,
       but it's not yet ready to receive payments.
     <% else %>
-      <% if @user.payout_detail %>
+      <% if @seller.payout_detail %>
         You have already provided your payout details. If you need to, you can <%= link_to 'change them', account_url %>.
       <% else %>
         <b>Important:</b> we need to know <%= link_to 'some details', account_url %> before we can make a

--- a/app/views/purchase_mailer/notify_artist.html.erb
+++ b/app/views/purchase_mailer/notify_artist.html.erb
@@ -4,11 +4,22 @@
   for <%= number_to_currency(@purchase.price, unit: "£") %>.</p>
 
 <p>
-  <% if @user.payout_detail %>
-    You have already provided your payout details. If you need to, you can <%= link_to 'change them', account_url %>.
+  <% if @stripe_account %>
+    <% if @stripe_account.accepts_payments? %>
+      A payment has been made to your
+      <%= link_to "Stripe account", link_stripe_connect_account_url(@stripe_account.stripe_identifier) %>.
+    <% else %>
+      You've started connecting a
+      <%= link_to "Stripe account", link_stripe_connect_account_url(@stripe_account.stripe_identifier) %>,
+      but it's not yet ready to receive payments.
+    <% end %>
   <% else %>
-    <b>Important:</b> we need to know <%= link_to 'some details', account_url %> before we can make a
+    <% if @user.payout_detail %>
+      You have already provided your payout details. If you need to, you can <%= link_to 'change them', account_url %>.
+    <% else %>
+      <b>Important:</b> we need to know <%= link_to 'some details', account_url %> before we can make a
       payment to you.
+    <% end %>
   <% end %>
 </p>
 

--- a/app/views/purchase_mailer/notify_artist.html.erb
+++ b/app/views/purchase_mailer/notify_artist.html.erb
@@ -3,12 +3,14 @@
 <p>Good news! You sold a copy of your album <%= @purchase.album.title %>
   for <%= number_to_currency(@purchase.price, unit: "£") %>.</p>
 
-<% if @user.payout_detail %>
-  <p>You have already provided your payout details. If you need to, you can <%= link_to 'change them', account_url %>.</p>
-<% else %>
-  <p><b>Important:</b> we need to know <%= link_to 'some details', account_url %> before we can make a
-    payment to you.</p>
-<% end %>
+<p>
+  <% if @user.payout_detail %>
+    You have already provided your payout details. If you need to, you can <%= link_to 'change them', account_url %>.
+  <% else %>
+    <b>Important:</b> we need to know <%= link_to 'some details', account_url %> before we can make a
+      payment to you.
+  <% end %>
+</p>
 
 <p>Thank you for selling your music with us,</p>
 

--- a/app/views/stripe_connect_account_mailer/charges_enabled.html.erb
+++ b/app/views/stripe_connect_account_mailer/charges_enabled.html.erb
@@ -1,0 +1,5 @@
+<p>Hey there,</p>
+
+<p>Good news! Your <%= link_to "Stripe account", link_stripe_connect_account_url(@account.stripe_identifier) %> is now ready to accept payments.</p>
+
+<p>The jam.coop team</p>

--- a/app/views/stripe_connect_account_mailer/payouts_enabled.html.erb
+++ b/app/views/stripe_connect_account_mailer/payouts_enabled.html.erb
@@ -1,0 +1,5 @@
+<p>Hey there,</p>
+
+<p>Good news! Your <%= link_to "Stripe account", link_stripe_connect_account_url(@account.stripe_identifier) %> now allows payouts to your bank account.</p>
+
+<p>The jam.coop team</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -121,6 +121,12 @@
             <% if stripe_connect_account.accepts_payments? %>
               Your <a class="underline" href="https://stripe.com">Stripe</a> account is <span class="font-bold">connected</span>.
               We will automatically make payments to this account on every purchase.
+              <% if stripe_connect_account.payouts_enabled? %>
+                Your Stripe account is <span class="font-bold">ready</span> to payout to your bank account.
+              <% else %>
+                However, your Stripe account is <span class="font-bold">not yet ready</span> to payout to your bank account.
+                Edit the account to address any outstanding issues.
+              <% end %>
             <% else %>
               You've started connecting a <a class="underline" href="https://stripe.com">Stripe</a> account,
               but it's <span class="font-bold">not yet ready</span> to receive payments.

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -117,9 +117,18 @@
 
       <%= render(SidebarSectionComponent.new(title: 'Stripe')) do %>
         <% if stripe_connect_account.persisted? %>
+          <p class="text-slate-500 mb-6">
+            <% if stripe_connect_account.accepts_payments? %>
+              Your <a class="underline" href="https://stripe.com">Stripe</a> account is <span class="font-bold">connected</span>.
+              We will automatically make payments to this account on every purchase.
+            <% else %>
+              You've started connecting a <a class="underline" href="https://stripe.com">Stripe</a> account,
+              but it's <span class="font-bold">not yet ready</span> to receive payments.
+              Edit the account to address any outstanding issues.
+            <% end %>
+          </p>
           <ul>
             <li>Account ID: <span class="font-bold"><%= stripe_connect_account.stripe_identifier %></span></li>
-            <li>Status: <span class="font-bold"><%= stripe_connect_account.status.humanize %></span></li>
           </ul>
           <div class="flex flex-row justify-end">
             <%= render(ButtonComponent.new(

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -129,6 +129,7 @@
           </p>
           <ul>
             <li>Account ID: <span class="font-bold"><%= stripe_connect_account.stripe_identifier %></span></li>
+            <li>Country / Region: <span class="font-bold"><%= stripe_connect_country_text_from_country_code(stripe_connect_account.country_code) %></span></li>
           </ul>
           <div class="flex flex-row justify-end">
             <%= render(ButtonComponent.new(
@@ -139,9 +140,11 @@
             )) %>
           </div>
         <% else %>
-          <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase.</p>
+          <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase. To connect your Stripe account we need the following:</p>
 
           <%= form_with(model: stripe_connect_account, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
+            <%= form.select :country_code, options_for_stripe_connect_country_select, include_blank: true, class: 'w-full' %>
+            <p class="text-slate-500 italic text-sm mb-3">The country/region in which the account holder resides, or in which the business is legally established.</p>
             <div class="flex flex-row justify-end">
               <%= form.submit "Connect Stripe", class: 'mt-3' %>
             </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -112,6 +112,22 @@
       <% end %>
     <% end %>
 
+    <%= render(SidebarSectionComponent.new(title: 'Stripe')) do %>
+      <% if @stripe_account %>
+        <ul>
+          <li>Account ID: <span class="font-bold"><%= @stripe_account.stripe_identifier %></span></li>
+          <li><%= link_to "Edit account", link_stripe_connect_account_path(@stripe_account.stripe_identifier), class: 'underline' %></li>
+          <li>Status: <span class="font-bold"><%= @stripe_account.status.humanize %></span></li>
+        </ul>
+      <% else %>
+        <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase.</p>
+
+        <%= form_with(url: stripe_connect_accounts_path, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
+          <%= form.submit "Connect Stripe", class: 'mt-3' %>
+        <% end %>
+      <% end %>
+    <% end %>
+
     <%= render(SidebarSectionComponent.new(title: 'Payout details')) do %>
       <p class="text-slate-500 mb-6">We use <a class="underline" href="https://wise.com">Wise</a> to payout to your bank account once a month. Wise will email you at <span class="font-bold"><%= Current.user.email %></span> to ask for your bank details. To make the payment we need the following:</p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -143,6 +143,7 @@
           <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase. To connect your Stripe account we need the following:</p>
 
           <%= form_with(model: stripe_connect_account, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
+            <%= render ModelErrorComponent.new(model: stripe_connect_account, model_name: 'Stripe Connect account') %>
             <%= form.select :country_code, options_for_stripe_connect_country_select, include_blank: true, class: 'w-full' %>
             <p class="text-slate-500 italic text-sm mb-3">The country/region in which the account holder resides, or in which the business is legally established.</p>
             <div class="flex flex-row justify-end">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -119,14 +119,23 @@
         <% if stripe_connect_account.persisted? %>
           <ul>
             <li>Account ID: <span class="font-bold"><%= stripe_connect_account.stripe_identifier %></span></li>
-            <li><%= link_to "Edit account", link_stripe_connect_account_path(stripe_connect_account.stripe_identifier), class: 'underline' %></li>
             <li>Status: <span class="font-bold"><%= stripe_connect_account.status.humanize %></span></li>
           </ul>
+          <div class="flex flex-row justify-end">
+            <%= render(ButtonComponent.new(
+              text: 'Edit account',
+              path: link_stripe_connect_account_path(stripe_connect_account.stripe_identifier),
+              link: true,
+              class: 'mt-3'
+            )) %>
+          </div>
         <% else %>
           <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase.</p>
 
           <%= form_with(model: stripe_connect_account, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
-            <%= form.submit "Connect Stripe", class: 'mt-3' %>
+            <div class="flex flex-row justify-end">
+              <%= form.submit "Connect Stripe", class: 'mt-3' %>
+            </div>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -145,7 +145,7 @@
           <%= form_with(model: stripe_connect_account, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
             <%= render ModelErrorComponent.new(model: stripe_connect_account, model_name: 'Stripe Connect account') %>
             <%= form.select :country_code, options_for_stripe_connect_country_select, include_blank: true, class: 'w-full' %>
-            <p class="text-slate-500 italic text-sm mb-3">The country/region in which the account holder resides, or in which the business is legally established.</p>
+            <p class="text-slate-500 italic text-sm mb-3">The country/region in which the account holder resides, or in which the business is legally established. We currently only support payouts to Stripe accounts in the United Kingdom.</p>
             <div class="flex flex-row justify-end">
               <%= form.submit "Connect Stripe", class: 'mt-3' %>
             </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -113,17 +113,19 @@
     <% end %>
 
     <% if @user.stripe_connect_enabled? %>
+      <% stripe_connect_account = @user.stripe_connect_account || @user.build_stripe_connect_account %>
+
       <%= render(SidebarSectionComponent.new(title: 'Stripe')) do %>
-        <% if @stripe_account %>
+        <% if stripe_connect_account.persisted? %>
           <ul>
-            <li>Account ID: <span class="font-bold"><%= @stripe_account.stripe_identifier %></span></li>
-            <li><%= link_to "Edit account", link_stripe_connect_account_path(@stripe_account.stripe_identifier), class: 'underline' %></li>
-            <li>Status: <span class="font-bold"><%= @stripe_account.status.humanize %></span></li>
+            <li>Account ID: <span class="font-bold"><%= stripe_connect_account.stripe_identifier %></span></li>
+            <li><%= link_to "Edit account", link_stripe_connect_account_path(stripe_connect_account.stripe_identifier), class: 'underline' %></li>
+            <li>Status: <span class="font-bold"><%= stripe_connect_account.status.humanize %></span></li>
           </ul>
         <% else %>
           <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase.</p>
 
-          <%= form_with(url: stripe_connect_accounts_path, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
+          <%= form_with(model: stripe_connect_account, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
             <%= form.submit "Connect Stripe", class: 'mt-3' %>
           <% end %>
         <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -112,18 +112,20 @@
       <% end %>
     <% end %>
 
-    <%= render(SidebarSectionComponent.new(title: 'Stripe')) do %>
-      <% if @stripe_account %>
-        <ul>
-          <li>Account ID: <span class="font-bold"><%= @stripe_account.stripe_identifier %></span></li>
-          <li><%= link_to "Edit account", link_stripe_connect_account_path(@stripe_account.stripe_identifier), class: 'underline' %></li>
-          <li>Status: <span class="font-bold"><%= @stripe_account.status.humanize %></span></li>
-        </ul>
-      <% else %>
-        <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase.</p>
+    <% if @user.stripe_connect_enabled? %>
+      <%= render(SidebarSectionComponent.new(title: 'Stripe')) do %>
+        <% if @stripe_account %>
+          <ul>
+            <li>Account ID: <span class="font-bold"><%= @stripe_account.stripe_identifier %></span></li>
+            <li><%= link_to "Edit account", link_stripe_connect_account_path(@stripe_account.stripe_identifier), class: 'underline' %></li>
+            <li>Status: <span class="font-bold"><%= @stripe_account.status.humanize %></span></li>
+          </ul>
+        <% else %>
+          <p class="text-slate-500 mb-6">We payout to connected <a class="underline" href="https://stripe.com">Stripe</a> accounts automatically on every purchase.</p>
 
-        <%= form_with(url: stripe_connect_accounts_path, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
-          <%= form.submit "Connect Stripe", class: 'mt-3' %>
+          <%= form_with(url: stripe_connect_accounts_path, data: { turbo: false }, class: "contents", builder: TailwindFormBuilder) do |form| %>
+            <%= form.submit "Connect Stripe", class: 'mt-3' %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,5 +46,7 @@ module MusicCoop
 
     config.mission_control.jobs.base_controller_class = 'AdminController'
     config.mission_control.jobs.http_basic_auth_enabled = false
+
+    config.platform_fee_percentage = 15
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,5 @@ en:
     attributes:
       payout_detail:
         country: Country / Region
+      stripe_connect_account:
+        country_code: Country / Region

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,13 @@ Rails.application.routes.draw do
   get 'account', to: 'users#show'
   get 'collection', to: 'collections#show'
 
+  resources :stripe_connect_accounts, only: %i[new create] do
+    member do
+      get :link
+      get :success
+    end
+  end
+
   resources :sessions, only: %i[index show destroy]
   resource  :password, only: %i[update]
   resource :payout_detail, only: %i[create update]

--- a/db/migrate/20260301162945_create_stripe_connect_accounts.rb
+++ b/db/migrate/20260301162945_create_stripe_connect_accounts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateStripeConnectAccounts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :stripe_connect_accounts do |t|
+      t.belongs_to :user
+      t.string :stripe_identifier, null: false
+      t.boolean :details_submitted, default: false, null: false
+      t.boolean :charges_enabled, default: false, null: false
+
+      t.timestamps
+    end
+
+    add_index :stripe_connect_accounts, :stripe_identifier
+  end
+end

--- a/db/migrate/20260301172841_add_payouts_enabled_to_stripe_connect_accounts.rb
+++ b/db/migrate/20260301172841_add_payouts_enabled_to_stripe_connect_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPayoutsEnabledToStripeConnectAccounts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :stripe_connect_accounts, :payouts_enabled, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20260324210115_add_stripe_connect_enabled_to_users.rb
+++ b/db/migrate/20260324210115_add_stripe_connect_enabled_to_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddStripeConnectEnabledToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :stripe_connect_enabled, :boolean, default: false
+
+    update 'UPDATE users SET stripe_connect_enabled = FALSE'
+
+    change_column_null :users, :stripe_connect_enabled, false
+  end
+end

--- a/db/migrate/20260327102440_create_payouts.rb
+++ b/db/migrate/20260327102440_create_payouts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreatePayouts < ActiveRecord::Migration[8.1]
+  def change
+    create_table :payouts do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+      t.string :payout_type, null: false
+      t.string :transaction_reference, null: false
+      t.string :destination_reference, null: false
+      t.integer :amount_in_pence, null: false
+      t.integer :platform_fee_in_pence, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260327151136_add_payout_id_to_purchases.rb
+++ b/db/migrate/20260327151136_add_payout_id_to_purchases.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPayoutIdToPurchases < ActiveRecord::Migration[8.1]
+  def change
+    add_reference :purchases, :payout, foreign_key: true
+  end
+end

--- a/db/migrate/20260331155018_make_stripe_identifier_on_stripe_connect_accounts_nullable.rb
+++ b/db/migrate/20260331155018_make_stripe_identifier_on_stripe_connect_accounts_nullable.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class MakeStripeIdentifierOnStripeConnectAccountsNullable < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :stripe_connect_accounts, :stripe_identifier, true
+  end
+end

--- a/db/migrate/20260331156351_add_country_code_to_stripe_connect_accounts.rb
+++ b/db/migrate/20260331156351_add_country_code_to_stripe_connect_accounts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddCountryCodeToStripeConnectAccounts < ActiveRecord::Migration[8.1]
+  def change
+    add_column :stripe_connect_accounts, :country_code, :string
+  end
+end

--- a/db/migrate/20260402105524_change_country_code_on_stripe_connect_accounts_to_not_null.rb
+++ b/db/migrate/20260402105524_change_country_code_on_stripe_connect_accounts_to_not_null.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ChangeCountryCodeOnStripeConnectAccountsToNotNull < ActiveRecord::Migration[8.1]
+  def change
+    update "UPDATE stripe_connect_accounts SET country_code = 'GB'"
+    change_column_null :stripe_connect_accounts, :country_code, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_155018) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_31_156351) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -319,6 +319,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_155018) do
 
   create_table "stripe_connect_accounts", force: :cascade do |t|
     t.boolean "charges_enabled", default: false, null: false
+    t.string "country_code"
     t.datetime "created_at", null: false
     t.boolean "details_submitted", default: false, null: false
     t.boolean "payouts_enabled", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_25_092614) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_01_162945) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -301,6 +301,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_25_092614) do
     t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
     t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
     t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  create_table "stripe_connect_accounts", force: :cascade do |t|
+    t.boolean "charges_enabled", default: false, null: false
+    t.datetime "created_at", null: false
+    t.boolean "details_submitted", default: false, null: false
+    t.string "stripe_identifier", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id"
+    t.index ["stripe_identifier"], name: "index_stripe_connect_accounts_on_stripe_identifier"
+    t.index ["user_id"], name: "index_stripe_connect_accounts_on_user_id"
   end
 
   create_table "taggings", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_27_151136) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_31_155018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -322,7 +322,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_27_151136) do
     t.datetime "created_at", null: false
     t.boolean "details_submitted", default: false, null: false
     t.boolean "payouts_enabled", default: false, null: false
-    t.string "stripe_identifier", null: false
+    t.string "stripe_identifier"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["stripe_identifier"], name: "index_stripe_connect_accounts_on_stripe_identifier"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_31_156351) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_02_105524) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -319,7 +319,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_31_156351) do
 
   create_table "stripe_connect_accounts", force: :cascade do |t|
     t.boolean "charges_enabled", default: false, null: false
-    t.string "country_code"
+    t.string "country_code", null: false
     t.datetime "created_at", null: false
     t.boolean "details_submitted", default: false, null: false
     t.boolean "payouts_enabled", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_27_102440) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_27_151136) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -166,12 +166,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_27_102440) do
     t.boolean "contact_opt_in", default: false, null: false
     t.datetime "created_at", null: false
     t.string "customer_email"
+    t.bigint "payout_id"
     t.decimal "price", precision: 8, scale: 2
     t.datetime "sending_suppressed_at"
     t.string "stripe_session_id"
     t.datetime "updated_at", null: false
     t.bigint "user_id"
     t.index ["album_id"], name: "index_purchases_on_album_id"
+    t.index ["payout_id"], name: "index_purchases_on_payout_id"
     t.index ["user_id"], name: "index_purchases_on_user_id"
   end
 
@@ -393,6 +395,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_27_102440) do
   add_foreign_key "payouts", "users"
   add_foreign_key "purchase_downloads", "purchases"
   add_foreign_key "purchases", "albums"
+  add_foreign_key "purchases", "payouts"
   add_foreign_key "purchases", "users"
   add_foreign_key "releases", "albums"
   add_foreign_key "releases", "labels"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_01_162945) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_01_172841) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -307,6 +307,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_162945) do
     t.boolean "charges_enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.boolean "details_submitted", default: false, null: false
+    t.boolean "payouts_enabled", default: false, null: false
     t.string "stripe_identifier", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_24_210115) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_27_102440) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -137,6 +137,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_210115) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_payout_details_on_user_id"
+  end
+
+  create_table "payouts", force: :cascade do |t|
+    t.integer "amount_in_pence", null: false
+    t.datetime "created_at", null: false
+    t.string "destination_reference", null: false
+    t.string "payout_type", null: false
+    t.integer "platform_fee_in_pence", null: false
+    t.string "transaction_reference", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_payouts_on_user_id"
   end
 
   create_table "purchase_downloads", force: :cascade do |t|
@@ -378,6 +390,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_24_210115) do
   add_foreign_key "labels", "users"
   add_foreign_key "password_reset_tokens", "users"
   add_foreign_key "payout_details", "users"
+  add_foreign_key "payouts", "users"
   add_foreign_key "purchase_downloads", "purchases"
   add_foreign_key "purchases", "albums"
   add_foreign_key "purchases", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_01_172841) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_24_210115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -363,6 +363,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_01_172841) do
     t.boolean "opt_in_to_newsletter", default: true, null: false
     t.string "password_digest", null: false
     t.datetime "sending_suppressed_at"
+    t.boolean "stripe_connect_enabled", default: false, null: false
     t.datetime "updated_at", null: false
     t.boolean "verified", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -6,7 +6,13 @@ User.create!(email: 'admin@example.com', password: 'admin-jam-coop', verified: t
 User.create!(email: 'fan@example.com', password: 'fan-jam-coop', verified: true)
 
 6.times do |i|
-  user = User.create(email: "artist-#{i}@example.com", password: "artist-#{i}-jam-coop", verified: true)
+  stripe_connect_enabled = i < 3
+  user = User.create(
+    email: "artist-#{i}@example.com",
+    password: "artist-#{i}-jam-coop",
+    verified: true,
+    stripe_connect_enabled:
+  )
   artist = Artist.create!(
     name: Faker::Music.band,
     location: [Faker::Address.city, Faker::Address.country].join(', '),

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -12,7 +12,7 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
   end
 
   test '#create creates a Stripe::Account' do
-    Stripe::Account.expects(:create).returns(@stripe_account)
+    Stripe::Account.expects(:create).with({ email: @user.email }).returns(@stripe_account)
 
     post stripe_connect_accounts_path
   end

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    log_in_as(@user)
+
+    @stripe_account = stub('Stripe::Account', id: 'acct-id')
+    Stripe::Account.stubs(:create).returns(@stripe_account)
+  end
+
+  test '#create creates a Stripe::Account' do
+    Stripe::Account.expects(:create).returns(@stripe_account)
+
+    post stripe_connect_accounts_path
+  end
+
+  test '#create creates a StripeConnectAccount to store the Stripe account ID' do
+    post stripe_connect_accounts_path
+
+    connect_account = StripeConnectAccount.last
+    assert_equal @user, connect_account.user
+    assert_equal @stripe_account.id, connect_account.stripe_identifier
+  end
+
+  test '#create redirects to the link action' do
+    post stripe_connect_accounts_path
+
+    assert_redirected_to link_stripe_connect_account_path(@stripe_account.id)
+  end
+end
+
+class StripeConnectAccountsControllerLinkTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    log_in_as(@user)
+
+    @stripe_account_id = 'acct-id'
+    StripeConnectAccount.create!(user: @user, stripe_identifier: @stripe_account_id)
+
+    url = success_stripe_connect_account_url(@stripe_account_id)
+    @stripe_account_link = stub('Stripe::AccountLink', url:)
+    Stripe::AccountLink.stubs(:create).returns(@stripe_account_link)
+  end
+
+  test '#link creates a Stripe::AccountLink' do
+    Stripe::AccountLink.expects(:create).with(
+      {
+        account: @stripe_account_id,
+        refresh_url: link_stripe_connect_account_url(@stripe_account_id),
+        return_url: success_stripe_connect_account_url(@stripe_account_id),
+        type: 'account_onboarding'
+      }
+    ).returns(@stripe_account_link)
+
+    get link_stripe_connect_account_path(@stripe_account_id)
+  end
+
+  test '#link redirects to Stripe::AccountLink#url' do
+    get link_stripe_connect_account_path(@stripe_account_id)
+
+    assert_redirected_to @stripe_account_link.url, allow_other_host: true
+  end
+end
+
+class StripeConnectAccountsControllerSuccessTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    log_in_as(@user)
+
+    @stripe_account_id = 'acct-id'
+    @stripe_connect_account = StripeConnectAccount.create!(user: @user, stripe_identifier: @stripe_account_id)
+
+    @stripe_account = stub(
+      'Stripe::Account', {
+        id: @stripe_account_id,
+        details_submitted?: false,
+        charges_enabled?: false
+      }
+    )
+  end
+
+  test '#success updates StripeConnectAccount#details_submitted?' do
+    @stripe_account.stubs(details_submitted?: true)
+    Stripe::Account.stubs(:retrieve).with(@stripe_account_id).returns(@stripe_account)
+
+    get success_stripe_connect_account_path(@stripe_account_id)
+
+    assert @stripe_connect_account.reload.details_submitted?
+  end
+
+  test '#success updates StripeConnectAccount#charges_enabled?' do
+    @stripe_account.stubs(charges_enabled?: true)
+    Stripe::Account.stubs(:retrieve).with(@stripe_account_id).returns(@stripe_account)
+
+    get success_stripe_connect_account_path(@stripe_account_id)
+
+    assert @stripe_connect_account.reload.charges_enabled?
+  end
+
+  test '#success redirects to account page' do
+    Stripe::Account.stubs(:retrieve).with(@stripe_account_id).returns(@stripe_account)
+
+    get success_stripe_connect_account_path(@stripe_account_id)
+
+    assert_redirected_to account_path
+  end
+end

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -77,7 +77,8 @@ class StripeConnectAccountsControllerSuccessTest < ActionDispatch::IntegrationTe
       'Stripe::Account', {
         id: @stripe_account_id,
         details_submitted?: false,
-        charges_enabled?: false
+        charges_enabled?: false,
+        payouts_enabled?: false
       }
     )
   end
@@ -98,6 +99,15 @@ class StripeConnectAccountsControllerSuccessTest < ActionDispatch::IntegrationTe
     get success_stripe_connect_account_path(@stripe_account_id)
 
     assert @stripe_connect_account.reload.charges_enabled?
+  end
+
+  test '#success updates StripeConnectAccount#payouts_enabled?' do
+    @stripe_account.stubs(payouts_enabled?: true)
+    Stripe::Account.stubs(:retrieve).with(@stripe_account_id).returns(@stripe_account)
+
+    get success_stripe_connect_account_path(@stripe_account_id)
+
+    assert @stripe_connect_account.reload.payouts_enabled?
   end
 
   test '#success redirects to account page' do

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -4,11 +4,19 @@ require 'test_helper'
 
 class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTest
   setup do
-    @user = create(:user)
+    @user = create(:user, stripe_connect_enabled: true)
     log_in_as(@user)
 
     @stripe_account = stub('Stripe::Account', id: 'acct-id')
     Stripe::Account.stubs(:create).returns(@stripe_account)
+  end
+
+  test '#create redirects to account page if Stripe Connect is disabled for user' do
+    @user.update!(stripe_connect_enabled: false)
+    post stripe_connect_accounts_path
+
+    assert_redirected_to account_path
+    assert_equal 'Stripe Connect is not available', flash[:alert]
   end
 
   test '#create creates a Stripe::Account' do
@@ -34,7 +42,7 @@ end
 
 class StripeConnectAccountsControllerLinkTest < ActionDispatch::IntegrationTest
   setup do
-    @user = create(:user)
+    @user = create(:user, stripe_connect_enabled: true)
     log_in_as(@user)
 
     @stripe_account_id = 'acct-id'
@@ -67,7 +75,7 @@ end
 
 class StripeConnectAccountsControllerSuccessTest < ActionDispatch::IntegrationTest
   setup do
-    @user = create(:user)
+    @user = create(:user, stripe_connect_enabled: true)
     log_in_as(@user)
 
     @stripe_account_id = 'acct-id'

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -13,7 +13,7 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
 
   test '#create redirects to account page if Stripe Connect is disabled for user' do
     @user.update!(stripe_connect_enabled: false)
-    post stripe_connect_accounts_path
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: 'GB' } }
 
     assert_redirected_to account_path
     assert_equal 'Stripe Connect is not available', flash[:alert]
@@ -35,15 +35,34 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
   end
 
   test '#create redirects to the link action' do
-    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: 'GB' } }
 
     assert_redirected_to link_stripe_connect_account_path(@stripe_account.id)
+  end
+
+  test '#create re-renders account page with flash alert if validation fails' do
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
+
+    assert_response :unprocessable_content
+    assert_equal 'Stripe Connect account is invalid', flash[:alert]
+  end
+
+  test '#create does not create a Stripe::Account if validation fails' do
+    Stripe::Account.expects(:create).never
+
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
+  end
+
+  test '#create does not create a StripeConnectAccount if validation fails' do
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
+
+    assert_nil @user.reload.stripe_connect_account
   end
 
   test '#create redirects to account page if error creating Stripe account via API' do
     Stripe::Account.stubs(:create).raises(Stripe::StripeError.new)
 
-    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: 'GB' } }
 
     assert_redirected_to account_path
     assert_equal 'Error creating Stripe Connect account', flash[:alert]
@@ -54,7 +73,7 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
     Stripe::Account.stubs(:create).raises(stripe_error)
     Rollbar.expects(:error).with(stripe_error)
 
-    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: 'GB' } }
   end
 end
 
@@ -64,7 +83,8 @@ class StripeConnectAccountsControllerLinkTest < ActionDispatch::IntegrationTest
     log_in_as(@user)
 
     @stripe_account_id = 'acct-id'
-    @user.create_stripe_connect_account!(stripe_identifier: @stripe_account_id)
+    attributes = attributes_for(:stripe_connect_account, stripe_identifier: @stripe_account_id)
+    @user.create_stripe_connect_account!(attributes)
 
     url = success_stripe_connect_account_url(@stripe_account_id)
     @stripe_account_link = stub('Stripe::AccountLink', url:)
@@ -97,7 +117,8 @@ class StripeConnectAccountsControllerSuccessTest < ActionDispatch::IntegrationTe
     log_in_as(@user)
 
     @stripe_account_id = 'acct-id'
-    @stripe_connect_account = @user.create_stripe_connect_account!(stripe_identifier: @stripe_account_id)
+    attributes = attributes_for(:stripe_connect_account, stripe_identifier: @stripe_account_id)
+    @stripe_connect_account = @user.create_stripe_connect_account!(attributes)
 
     @stripe_account = stub(
       'Stripe::Account', {

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -20,21 +20,22 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
   end
 
   test '#create creates a Stripe::Account' do
-    Stripe::Account.expects(:create).with({ email: @user.email }).returns(@stripe_account)
+    Stripe::Account.expects(:create).with({ email: @user.email, country: 'GB' }).returns(@stripe_account)
 
-    post stripe_connect_accounts_path
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: 'GB' } }
   end
 
   test '#create creates a StripeConnectAccount to store the Stripe account ID' do
-    post stripe_connect_accounts_path
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: 'GB' } }
 
     connect_account = StripeConnectAccount.last
     assert_equal @user, connect_account.user
+    assert_equal 'GB', connect_account.country_code
     assert_equal @stripe_account.id, connect_account.stripe_identifier
   end
 
   test '#create redirects to the link action' do
-    post stripe_connect_accounts_path
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
 
     assert_redirected_to link_stripe_connect_account_path(@stripe_account.id)
   end
@@ -42,7 +43,7 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
   test '#create redirects to account page if error creating Stripe account via API' do
     Stripe::Account.stubs(:create).raises(Stripe::StripeError.new)
 
-    post stripe_connect_accounts_path
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
 
     assert_redirected_to account_path
     assert_equal 'Error creating Stripe Connect account', flash[:alert]
@@ -53,7 +54,7 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
     Stripe::Account.stubs(:create).raises(stripe_error)
     Rollbar.expects(:error).with(stripe_error)
 
-    post stripe_connect_accounts_path
+    post stripe_connect_accounts_path, params: { stripe_connect_account: { country_code: '' } }
   end
 end
 

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -46,7 +46,7 @@ class StripeConnectAccountsControllerLinkTest < ActionDispatch::IntegrationTest
     log_in_as(@user)
 
     @stripe_account_id = 'acct-id'
-    StripeConnectAccount.create!(user: @user, stripe_identifier: @stripe_account_id)
+    @user.create_stripe_connect_account!(stripe_identifier: @stripe_account_id)
 
     url = success_stripe_connect_account_url(@stripe_account_id)
     @stripe_account_link = stub('Stripe::AccountLink', url:)
@@ -79,7 +79,7 @@ class StripeConnectAccountsControllerSuccessTest < ActionDispatch::IntegrationTe
     log_in_as(@user)
 
     @stripe_account_id = 'acct-id'
-    @stripe_connect_account = StripeConnectAccount.create!(user: @user, stripe_identifier: @stripe_account_id)
+    @stripe_connect_account = @user.create_stripe_connect_account!(stripe_identifier: @stripe_account_id)
 
     @stripe_account = stub(
       'Stripe::Account', {

--- a/test/controllers/stripe_connect_accounts_controller_test.rb
+++ b/test/controllers/stripe_connect_accounts_controller_test.rb
@@ -38,6 +38,23 @@ class StripeConnectAccountsControllerCreateTest < ActionDispatch::IntegrationTes
 
     assert_redirected_to link_stripe_connect_account_path(@stripe_account.id)
   end
+
+  test '#create redirects to account page if error creating Stripe account via API' do
+    Stripe::Account.stubs(:create).raises(Stripe::StripeError.new)
+
+    post stripe_connect_accounts_path
+
+    assert_redirected_to account_path
+    assert_equal 'Error creating Stripe Connect account', flash[:alert]
+  end
+
+  test '#create reports exception to Rollbar if error creating Stripe account via API' do
+    stripe_error = Stripe::StripeError.new
+    Stripe::Account.stubs(:create).raises(stripe_error)
+    Rollbar.expects(:error).with(stripe_error)
+
+    post stripe_connect_accounts_path
+  end
 end
 
 class StripeConnectAccountsControllerLinkTest < ActionDispatch::IntegrationTest

--- a/test/controllers/stripe_webhook_events_controller_test.rb
+++ b/test/controllers/stripe_webhook_events_controller_test.rb
@@ -42,6 +42,19 @@ class StripeWebhookEventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'account.updated updates Stripe Connect account status when payouts enabled' do
+    stripe_identifier = 'acct_test_12345'
+    stripe_connect_account = create(:stripe_connect_account, stripe_identifier:)
+
+    params = account_updated_params(stripe_identifier, payouts_enabled: true)
+    headers = headers_for_event(params)
+
+    post stripe_webhook_events_path, params:, headers:, as: :json
+
+    assert stripe_connect_account.reload.payouts_enabled?
+    assert_response :success
+  end
+
   test 'invalid signature in payload' do
     post stripe_webhook_events_path, params: {}, headers: {}, as: :json
 
@@ -81,7 +94,8 @@ class StripeWebhookEventsControllerTest < ActionDispatch::IntegrationTest
   def account_updated_params(stripe_account_id, **statuses)
     statuses.with_defaults!(
       details_submitted: false,
-      charges_enabled: false
+      charges_enabled: false,
+      payouts_enabled: false
     )
     {
       type: 'account.updated',

--- a/test/controllers/stripe_webhook_events_controller_test.rb
+++ b/test/controllers/stripe_webhook_events_controller_test.rb
@@ -16,6 +16,32 @@ class StripeWebhookEventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test 'account.updated updates Stripe Connect account status when details submitted' do
+    stripe_identifier = 'acct_test_12345'
+    stripe_connect_account = create(:stripe_connect_account, stripe_identifier:)
+
+    params = account_updated_params(stripe_identifier, details_submitted: true)
+    headers = headers_for_event(params)
+
+    post stripe_webhook_events_path, params:, headers:, as: :json
+
+    assert stripe_connect_account.reload.details_submitted?
+    assert_response :success
+  end
+
+  test 'account.updated updates Stripe Connect account status when charges enabled' do
+    stripe_identifier = 'acct_test_12345'
+    stripe_connect_account = create(:stripe_connect_account, stripe_identifier:)
+
+    params = account_updated_params(stripe_identifier, charges_enabled: true)
+    headers = headers_for_event(params)
+
+    post stripe_webhook_events_path, params:, headers:, as: :json
+
+    assert stripe_connect_account.reload.charges_enabled?
+    assert_response :success
+  end
+
   test 'invalid signature in payload' do
     post stripe_webhook_events_path, params: {}, headers: {}, as: :json
 
@@ -47,6 +73,22 @@ class StripeWebhookEventsControllerTest < ActionDispatch::IntegrationTest
       data: {
         object: {
           id: checkout_session_id
+        }
+      }
+    }
+  end
+
+  def account_updated_params(stripe_account_id, **statuses)
+    statuses.with_defaults!(
+      details_submitted: false,
+      charges_enabled: false
+    )
+    {
+      type: 'account.updated',
+      data: {
+        object: {
+          id: stripe_account_id,
+          **statuses
         }
       }
     }

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -44,7 +44,7 @@ class UsersControllerTestSignedIn < ActionDispatch::IntegrationTest
     end
   end
 
-  test '#show displays status if Stripe Connect account has charges enabled' do
+  test '#show displays status if Stripe Connect account has charges enabled, but payouts disabled' do
     @user.update!(stripe_connect_enabled: true)
     attributes = attributes_for(:stripe_connect_account, charges_enabled: true)
     @user.create_stripe_connect_account(attributes)
@@ -54,7 +54,25 @@ class UsersControllerTestSignedIn < ActionDispatch::IntegrationTest
     assert_select stripe_connect_section_selector do
       assert_select(
         'p',
-        'Your Stripe account is connected. We will automatically make payments to this account on every purchase.'
+        'Your Stripe account is connected. We will automatically make payments to this account on every purchase. ' \
+        'However, your Stripe account is not yet ready to payout to your bank account. ' \
+        'Edit the account to address any outstanding issues.'
+      )
+    end
+  end
+
+  test '#show displays status if Stripe Connect account has charged enabled and payouts enabled' do
+    @user.update!(stripe_connect_enabled: true)
+    attributes = attributes_for(:stripe_connect_account, charges_enabled: true, payouts_enabled: true)
+    @user.create_stripe_connect_account(attributes)
+
+    get account_path
+
+    assert_select stripe_connect_section_selector do
+      assert_select(
+        'p',
+        'Your Stripe account is connected. We will automatically make payments to this account on every purchase. ' \
+        'Your Stripe account is ready to payout to your bank account.'
       )
     end
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -13,6 +13,21 @@ class UsersControllerTestSignedIn < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test '#show does not display button to setup Stripe Connect if Stripe Connect is disabled for user' do
+    @user.update!(stripe_connect_enabled: false)
+    get account_path
+
+    assert_select 'input[type=submit][value=?]', 'Connect Stripe', count: 0
+  end
+
+  test '#show displays button to setup Stripe Connect if Stripe Connect is enabled for user' do
+    @user.update!(stripe_connect_enabled: true)
+
+    get account_path
+
+    assert_select 'input[type=submit][value=?]', 'Connect Stripe'
+  end
+
   test '#update_newsletter_preference can opt out of newsletter' do
     assert @user.opt_in_to_newsletter
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -28,6 +28,37 @@ class UsersControllerTestSignedIn < ActionDispatch::IntegrationTest
     assert_select 'input[type=submit][value=?]', 'Connect Stripe'
   end
 
+  test '#show displays status if user has submitted details for Stripe Connect account' do
+    @user.update!(stripe_connect_enabled: true)
+    attributes = attributes_for(:stripe_connect_account, details_submitted: true)
+    @user.create_stripe_connect_account(attributes)
+
+    get account_path
+
+    assert_select stripe_connect_section_selector do
+      assert_select(
+        'p',
+        "You've started connecting a Stripe account, but it's not yet ready to receive payments. " \
+        'Edit the account to address any outstanding issues.'
+      )
+    end
+  end
+
+  test '#show displays status if Stripe Connect account has charges enabled' do
+    @user.update!(stripe_connect_enabled: true)
+    attributes = attributes_for(:stripe_connect_account, charges_enabled: true)
+    @user.create_stripe_connect_account(attributes)
+
+    get account_path
+
+    assert_select stripe_connect_section_selector do
+      assert_select(
+        'p',
+        'Your Stripe account is connected. We will automatically make payments to this account on every purchase.'
+      )
+    end
+  end
+
   test '#update_newsletter_preference can opt out of newsletter' do
     assert @user.opt_in_to_newsletter
 
@@ -36,6 +67,12 @@ class UsersControllerTestSignedIn < ActionDispatch::IntegrationTest
     assert_redirected_to account_path
     assert_equal 'Newsletter preference updated successfully.', flash[:notice]
     assert_not @user.reload.opt_in_to_newsletter
+  end
+
+  private
+
+  def stripe_connect_section_selector
+    "section.sidebar-section:has(h2:contains('Stripe'))"
   end
 end
 

--- a/test/factories/payouts.rb
+++ b/test/factories/payouts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :payout do
+    user
+    payout_type { 'Unknown' }
+    sequence(:transaction_reference) { |n| "transaction-ref-#{n}" }
+    sequence(:destination_reference) { |n| "destination-ref-#{n}" }
+    amount_in_pence { 500 }
+    platform_fee_in_pence { 100 }
+  end
+end

--- a/test/factories/payouts.rb
+++ b/test/factories/payouts.rb
@@ -9,4 +9,8 @@ FactoryBot.define do
     amount_in_pence { 500 }
     platform_fee_in_pence { 100 }
   end
+
+  factory :stripe_payout, parent: :payout do
+    payout_type { Payout::STRIPE_TYPE }
+  end
 end

--- a/test/factories/stripe_connect_accounts.rb
+++ b/test/factories/stripe_connect_accounts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :stripe_connect_account do
+    user
+    sequence(:stripe_identifier) { |n| "stripe-identifier-#{n}" }
+  end
+end

--- a/test/factories/stripe_connect_accounts.rb
+++ b/test/factories/stripe_connect_accounts.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :stripe_connect_account do
     user
+    country_code { 'GB' }
     sequence(:stripe_identifier) { |n| "stripe-identifier-#{n}" }
   end
 end

--- a/test/helpers/stripe_connect_account_helper_test.rb
+++ b/test/helpers/stripe_connect_account_helper_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StripeConnectAccountHelperTest < ActionView::TestCase
+  test 'options_for_stripe_connect_country_select only include UK' do
+    options = options_for_stripe_connect_country_select
+
+    assert_equal 1, options.length
+    assert_equal '🇬🇧 United Kingdom (GBP)', options[0].first
+    assert_equal 'GB', options[0].last
+  end
+
+  test 'returns country/region option text for country code' do
+    assert_equal '🇬🇧 United Kingdom (GBP)', stripe_connect_country_text_from_country_code('GB')
+  end
+end

--- a/test/jobs/purchase_complete_job_test.rb
+++ b/test/jobs/purchase_complete_job_test.rb
@@ -73,7 +73,7 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
 
     PurchaseCompleteJob.perform_now(stripe_session_id)
 
-    payouts = purchase.album.artist.user.payouts
+    payouts = purchase.seller.payouts
     assert_equal 1, payouts.length
     payout = payouts.last
     assert payout.stripe?

--- a/test/jobs/purchase_complete_job_test.rb
+++ b/test/jobs/purchase_complete_job_test.rb
@@ -10,7 +10,8 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     customer_email = 'email@example.com'
     amount_tax = 140
     purchase = create(:purchase, price: 7.00, stripe_session_id:)
-    stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    stub_retrieve_stripe_payment_intent(session.payment_intent)
 
     PurchaseCompleteJob.perform_now(stripe_session_id)
 
@@ -25,7 +26,8 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     customer_email = user.email
     amount_tax = 140
     purchase = create(:purchase, price: 7.00, stripe_session_id:)
-    stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    stub_retrieve_stripe_payment_intent(session.payment_intent)
 
     PurchaseCompleteJob.perform_now(stripe_session_id)
 
@@ -38,7 +40,8 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     customer_email = 'non-existant-email'
     amount_tax = 140
     purchase = create(:purchase, price: 7.00, user:, stripe_session_id:)
-    stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    stub_retrieve_stripe_payment_intent(session.payment_intent)
 
     PurchaseCompleteJob.perform_now(stripe_session_id)
 
@@ -50,7 +53,8 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     customer_email = 'email@example.com'
     amount_tax = 140
     purchase = create(:purchase, price: 7.00, stripe_session_id:)
-    stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    stub_retrieve_stripe_payment_intent(session.payment_intent)
 
     assert_enqueued_email_with PurchaseMailer, :completed, params: { purchase: } do
       PurchaseCompleteJob.perform_now(stripe_session_id)
@@ -62,7 +66,8 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     customer_email = 'email@example.com'
     amount_tax = 140
     purchase = create(:purchase, price: 7.00, stripe_session_id:)
-    stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    stub_retrieve_stripe_payment_intent(session.payment_intent)
 
     assert_enqueued_email_with PurchaseMailer, :notify_artist, params: { purchase: } do
       PurchaseCompleteJob.perform_now(stripe_session_id)

--- a/test/jobs/purchase_complete_job_test.rb
+++ b/test/jobs/purchase_complete_job_test.rb
@@ -61,6 +61,30 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'it creates a payout associated with the seller and the purchase' do
+    stripe_session_id = 'session-id'
+    customer_email = 'email@example.com'
+    amount_tax = 140
+    purchase = create(:purchase, price: 7.00, stripe_session_id:)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    payment_intent_id = session.payment_intent
+    destination = 'acct_1T7Y4RLr1GW0yJYq'
+    stub_retrieve_stripe_payment_intent(payment_intent_id, 840, 105, { destination:, amount: 700 })
+
+    PurchaseCompleteJob.perform_now(stripe_session_id)
+
+    payouts = purchase.album.artist.user.payouts
+    assert_equal 1, payouts.length
+    payout = payouts.last
+    assert payout.stripe?
+    assert_equal payout.transaction_reference, payment_intent_id
+    assert_equal payout.destination_reference, destination
+    assert_equal payout.amount_in_pence, 700
+    assert_equal payout.platform_fee_in_pence, 105
+
+    assert_equal payout, purchase.reload.payout
+  end
+
   test 'it emails the artist' do
     stripe_session_id = 'session-id'
     customer_email = 'email@example.com'

--- a/test/lib/purchase_exporter_test.rb
+++ b/test/lib/purchase_exporter_test.rb
@@ -49,12 +49,12 @@ class PurchaseExporterTest < ActiveSupport::TestCase
 
     export = PurchaseExporter.new(@today).to_csv
 
-    assert_includes export, purchase.album.artist.user.email
+    assert_includes export, purchase.seller.email
   end
 
   test 'export includes artists payout details' do
     purchase = create(:purchase, created_at: Date.new(2023, 12, 1))
-    payout_detail = create(:payout_detail, user: purchase.album.artist.user)
+    payout_detail = create(:payout_detail, user: purchase.seller)
 
     export = PurchaseExporter.new(@today).to_csv
 

--- a/test/lib/purchase_exporter_test.rb
+++ b/test/lib/purchase_exporter_test.rb
@@ -25,6 +25,16 @@ class PurchaseExporterTest < ActiveSupport::TestCase
     assert_not_includes export, excluded_purchase.id
   end
 
+  test 'export only includes purchases without a corresponding payout' do
+    included_purchase = create(:purchase, completed: true, created_at: Date.new(2023, 12, 1))
+    payout = build(:stripe_payout)
+    excluded_purchase = create(:purchase, completed: true, created_at: Date.new(2023, 12, 1), payout:)
+    export = PurchaseExporter.new(@today).to_csv
+
+    assert_includes export, included_purchase.id
+    assert_not_includes export, excluded_purchase.id
+  end
+
   test 'export includes purchase details' do
     create(:purchase, price: 7.00, amount_tax: 123, created_at: Date.new(2023, 12, 1))
 

--- a/test/mailers/previews/purchase_mailer_preview.rb
+++ b/test/mailers/previews/purchase_mailer_preview.rb
@@ -4,9 +4,9 @@ class PurchaseMailerPreview < ActionMailer::Preview
   include FactoryBot::Syntax::Methods
 
   def notify_artist
-    user = build(:user)
+    seller = build(:user)
     album = build(:album)
-    user.artists << album.artist
+    seller.artists << album.artist
     purchase = build(:purchase, album:, price: album.price)
 
     PurchaseMailer.with(purchase:).notify_artist

--- a/test/mailers/previews/stripe_connect_account_mailer_preview.rb
+++ b/test/mailers/previews/stripe_connect_account_mailer_preview.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class StripeConnectAccountMailerPreview < ActionMailer::Preview
+  include FactoryBot::Syntax::Methods
+
+  def charges_enabled
+    account = build(:stripe_connect_account)
+
+    StripeConnectAccountMailer.with(account:).charges_enabled
+  end
+
+  def payouts_enabled
+    account = build(:stripe_connect_account)
+
+    StripeConnectAccountMailer.with(account:).payouts_enabled
+  end
+end

--- a/test/mailers/purchase_mailer_test.rb
+++ b/test/mailers/purchase_mailer_test.rb
@@ -34,6 +34,36 @@ class PurchaseMailerTest < ActionMailer::TestCase
     assert_includes mail.body.to_s, 'for £7.00'
   end
 
+  test 'notify_artist with connected Stripe account accepting payments' do
+    stripe_connect_account = build(:stripe_connect_account, charges_enabled: true)
+    user = build(:user, stripe_connect_account:)
+    album = build(:album)
+    user.artists << album.artist
+    purchase = build(:purchase, album:, price: 7.00)
+
+    mail = PurchaseMailer.with(purchase:).notify_artist
+
+    assert_equal "You have sold a copy of #{album.title}", mail.subject
+    assert_equal [user.email], mail.to
+    assert_includes mail.body.to_s, 'for £7.00'
+    assert_includes mail.body.to_s, 'A payment has been made to your'
+    assert_includes mail.body.to_s, link_stripe_connect_account_url(stripe_connect_account.stripe_identifier)
+  end
+
+  test 'notify_artist with connected Stripe account not accepting payments' do
+    stripe_connect_account = build(:stripe_connect_account, details_submitted: true)
+    user = build(:user, stripe_connect_account:)
+    album = build(:album)
+    user.artists << album.artist
+    purchase = build(:purchase, album:, price: 7.00)
+
+    mail = PurchaseMailer.with(purchase:).notify_artist
+
+    assert_includes mail.body.to_s, "You've started connecting"
+    assert_includes mail.body.to_s, link_stripe_connect_account_url(stripe_connect_account.stripe_identifier)
+    assert_includes mail.body.to_s, "but it's not yet ready to receive payments"
+  end
+
   test 'notify_artist does not send if the artist has no associated user' do
     artist = build(:artist, user: nil)
     album = build(:album, artist:)

--- a/test/mailers/purchase_mailer_test.rb
+++ b/test/mailers/purchase_mailer_test.rb
@@ -34,20 +34,23 @@ class PurchaseMailerTest < ActionMailer::TestCase
     assert_includes mail.body.to_s, 'for £7.00'
   end
 
-  test 'notify_artist with connected Stripe account accepting payments' do
+  test 'notify_artist with Stripe payout associated with purchase' do
     stripe_connect_account = build(:stripe_connect_account, charges_enabled: true)
     user = build(:user, stripe_connect_account:)
     album = build(:album)
     user.artists << album.artist
-    purchase = build(:purchase, album:, price: 7.00)
+    payout = build(:stripe_payout, amount_in_pence: 595, platform_fee_in_pence: 105)
+    purchase = build(:purchase, album:, price: 7.00, payout:)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
 
     assert_equal "You have sold a copy of #{album.title}", mail.subject
     assert_equal [user.email], mail.to
     assert_includes mail.body.to_s, 'for £7.00'
-    assert_includes mail.body.to_s, 'A payment has been made to your'
+    assert_includes mail.body.to_s, 'A payment of £5.95 has been made to your'
     assert_includes mail.body.to_s, link_stripe_connect_account_url(stripe_connect_account.stripe_identifier)
+    assert_includes mail.body.to_s, 'A platform fee of £1.05 was deducted.'
+    assert_includes mail.body.to_s, 'Other Stripe fees may have been incurred (e.g. currency conversion fees).'
   end
 
   test 'notify_artist with connected Stripe account not accepting payments' do

--- a/test/mailers/purchase_mailer_test.rb
+++ b/test/mailers/purchase_mailer_test.rb
@@ -22,30 +22,30 @@ class PurchaseMailerTest < ActionMailer::TestCase
   end
 
   test 'notify_artist' do
-    user = build(:user)
+    seller = build(:user)
     album = build(:album)
-    user.artists << album.artist
+    seller.artists << album.artist
     purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
 
     assert_equal "You have sold a copy of #{album.title}", mail.subject
-    assert_equal [user.email], mail.to
+    assert_equal [seller.email], mail.to
     assert_includes mail.body.to_s, 'for £7.00'
   end
 
   test 'notify_artist with Stripe payout associated with purchase' do
     stripe_connect_account = build(:stripe_connect_account, charges_enabled: true)
-    user = build(:user, stripe_connect_account:)
+    seller = build(:user, stripe_connect_account:)
     album = build(:album)
-    user.artists << album.artist
+    seller.artists << album.artist
     payout = build(:stripe_payout, amount_in_pence: 595, platform_fee_in_pence: 105)
     purchase = create(:purchase, album:, price: 7.00, payout:)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
 
     assert_equal "You have sold a copy of #{album.title}", mail.subject
-    assert_equal [user.email], mail.to
+    assert_equal [seller.email], mail.to
     assert_includes mail.body.to_s, 'for £7.00'
     assert_includes mail.body.to_s, 'A payment of £5.95 has been made to your'
     assert_includes mail.body.to_s, link_stripe_connect_account_url(stripe_connect_account.stripe_identifier)
@@ -55,9 +55,9 @@ class PurchaseMailerTest < ActionMailer::TestCase
 
   test 'notify_artist with connected Stripe account not accepting payments' do
     stripe_connect_account = build(:stripe_connect_account, details_submitted: true)
-    user = build(:user, stripe_connect_account:)
+    seller = build(:user, stripe_connect_account:)
     album = build(:album)
-    user.artists << album.artist
+    seller.artists << album.artist
     purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
@@ -77,9 +77,9 @@ class PurchaseMailerTest < ActionMailer::TestCase
   end
 
   test 'notify_artist asks user to complete payout details' do
-    user = build(:user)
+    seller = build(:user)
     album = build(:album)
-    user.artists << album.artist
+    seller.artists << album.artist
     purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
@@ -87,10 +87,10 @@ class PurchaseMailerTest < ActionMailer::TestCase
   end
 
   test 'notify_artist allows user to change/verify payout details' do
-    user = build(:user)
-    build(:payout_detail, user:)
+    seller = build(:user)
+    build(:payout_detail, user: seller)
     album = build(:album)
-    user.artists << album.artist
+    seller.artists << album.artist
     purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
@@ -98,9 +98,9 @@ class PurchaseMailerTest < ActionMailer::TestCase
   end
 
   test 'do not notify artist of purchase if sending is suppressed' do
-    user = build(:user, sending_suppressed_at: Time.current)
+    seller = build(:user, sending_suppressed_at: Time.current)
     album = build(:album)
-    user.artists << album.artist
+    seller.artists << album.artist
     purchase = create(:purchase, album:, price: 7.00)
 
     PurchaseMailer.with(purchase:).notify_artist.deliver_now!

--- a/test/mailers/purchase_mailer_test.rb
+++ b/test/mailers/purchase_mailer_test.rb
@@ -16,7 +16,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
   end
 
   test 'do not send purchase completed email if sending is suppressed' do
-    purchase = build(:purchase, customer_email: 'email@example.com', sending_suppressed_at: Time.current)
+    purchase = create(:purchase, customer_email: 'email@example.com', sending_suppressed_at: Time.current)
     PurchaseMailer.with(purchase:).completed.deliver_now!
     assert_emails 0
   end
@@ -25,7 +25,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
     user = build(:user)
     album = build(:album)
     user.artists << album.artist
-    purchase = build(:purchase, album:, price: 7.00)
+    purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
 
@@ -40,7 +40,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
     album = build(:album)
     user.artists << album.artist
     payout = build(:stripe_payout, amount_in_pence: 595, platform_fee_in_pence: 105)
-    purchase = build(:purchase, album:, price: 7.00, payout:)
+    purchase = create(:purchase, album:, price: 7.00, payout:)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
 
@@ -58,7 +58,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
     user = build(:user, stripe_connect_account:)
     album = build(:album)
     user.artists << album.artist
-    purchase = build(:purchase, album:, price: 7.00)
+    purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
 
@@ -70,7 +70,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
   test 'notify_artist does not send if the artist has no associated user' do
     artist = build(:artist, user: nil)
     album = build(:album, artist:)
-    purchase = build(:purchase, album:, price: 7.00)
+    purchase = create(:purchase, album:, price: 7.00)
 
     PurchaseMailer.with(purchase:).notify_artist.deliver_now!
     assert_emails 0
@@ -80,7 +80,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
     user = build(:user)
     album = build(:album)
     user.artists << album.artist
-    purchase = build(:purchase, album:, price: 7.00)
+    purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
     assert_includes mail.body.to_s, account_url
@@ -91,7 +91,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
     build(:payout_detail, user:)
     album = build(:album)
     user.artists << album.artist
-    purchase = build(:purchase, album:, price: 7.00)
+    purchase = create(:purchase, album:, price: 7.00)
 
     mail = PurchaseMailer.with(purchase:).notify_artist
     assert_includes mail.body.to_s, account_url
@@ -101,7 +101,7 @@ class PurchaseMailerTest < ActionMailer::TestCase
     user = build(:user, sending_suppressed_at: Time.current)
     album = build(:album)
     user.artists << album.artist
-    purchase = build(:purchase, album:, price: 7.00)
+    purchase = create(:purchase, album:, price: 7.00)
 
     PurchaseMailer.with(purchase:).notify_artist.deliver_now!
     assert_emails 0

--- a/test/mailers/stripe_connect_account_mailer_test.rb
+++ b/test/mailers/stripe_connect_account_mailer_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StripeConnectAccountMailerTest < ActionMailer::TestCase
+  test 'charges_enabled' do
+    account = build(:stripe_connect_account)
+
+    mail = StripeConnectAccountMailer.with(account:).charges_enabled
+
+    assert_equal 'Your Stripe account now accepts payments', mail.subject
+    assert_equal [account.user.email], mail.to
+  end
+
+  test 'payouts_enabled' do
+    account = build(:stripe_connect_account)
+
+    mail = StripeConnectAccountMailer.with(account:).payouts_enabled
+
+    assert_equal 'Your Stripe account now allows payouts', mail.subject
+    assert_equal [account.user.email], mail.to
+  end
+end

--- a/test/models/payout_test.rb
+++ b/test/models/payout_test.rb
@@ -45,4 +45,14 @@ class PayoutTest < ActiveSupport::TestCase
     payout.destroy!
     assert purchases.map(&:reload).map(&:payout).all?(&:nil?)
   end
+
+  test 'is Stripe payout if payout_type is stripe' do
+    payout = create(:stripe_payout)
+    assert payout.stripe?
+  end
+
+  test 'is not Stripe payout if payout_type is not stripe' do
+    payout = create(:payout)
+    assert_not payout.stripe?
+  end
 end

--- a/test/models/payout_test.rb
+++ b/test/models/payout_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PayoutTest < ActiveSupport::TestCase
+  test 'factory is valid' do
+    assert build(:payout).valid?
+  end
+
+  test 'payout_type is required' do
+    assert_not build(:payout, payout_type: nil).valid?
+  end
+
+  test 'transaction_reference is required' do
+    assert_not build(:payout, transaction_reference: nil).valid?
+  end
+
+  test 'destination_reference is required' do
+    assert_not build(:payout, destination_reference: nil).valid?
+  end
+
+  test 'amount_in_pence is required' do
+    assert_not build(:payout, amount_in_pence: nil).valid?
+  end
+
+  test 'platform_fee_in_pence is required' do
+    assert_not build(:payout, platform_fee_in_pence: nil).valid?
+  end
+
+  test 'belongs to user' do
+    user = build(:user)
+    payout = create(:payout, user:)
+    assert_equal user, payout.user
+  end
+end

--- a/test/models/payout_test.rb
+++ b/test/models/payout_test.rb
@@ -55,4 +55,9 @@ class PayoutTest < ActiveSupport::TestCase
     payout = create(:payout)
     assert_not payout.stripe?
   end
+
+  test 'amount is in pounds' do
+    payout = create(:payout, amount_in_pence: 456)
+    assert_in_delta 4.56, payout.amount, 0.001
+  end
 end

--- a/test/models/payout_test.rb
+++ b/test/models/payout_test.rb
@@ -60,4 +60,9 @@ class PayoutTest < ActiveSupport::TestCase
     payout = create(:payout, amount_in_pence: 456)
     assert_in_delta 4.56, payout.amount, 0.001
   end
+
+  test 'platform_fee is in pounds' do
+    payout = create(:payout, platform_fee_in_pence: 123)
+    assert_in_delta 1.23, payout.platform_fee, 0.001
+  end
 end

--- a/test/models/payout_test.rb
+++ b/test/models/payout_test.rb
@@ -32,4 +32,17 @@ class PayoutTest < ActiveSupport::TestCase
     payout = create(:payout, user:)
     assert_equal user, payout.user
   end
+
+  test 'has many purchases' do
+    purchases = build_list(:purchase, 2)
+    payout = create(:payout, purchases:)
+    assert_equal purchases, payout.purchases
+  end
+
+  test 'foreign key on purchases is nullified on destruction' do
+    purchases = build_list(:purchase, 2)
+    payout = create(:payout, purchases:)
+    payout.destroy!
+    assert purchases.map(&:reload).map(&:payout).all?(&:nil?)
+  end
 end

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -75,4 +75,13 @@ class PurchaseTest < ActiveSupport::TestCase
     purchase = create(:purchase, payout:)
     assert_equal payout, purchase.payout
   end
+
+  test '.without_payout' do
+    payout = build(:payout)
+    purchase_with_payout = create(:purchase, payout:)
+    purchase_without_payout = create(:purchase)
+    purchases = Purchase.without_payout
+    assert_includes purchases, purchase_without_payout
+    assert_not_includes purchases, purchase_with_payout
+  end
 end

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -84,4 +84,21 @@ class PurchaseTest < ActiveSupport::TestCase
     assert_includes purchases, purchase_without_payout
     assert_not_includes purchases, purchase_with_payout
   end
+
+  test '#stripe_payout returns nil if no payout' do
+    purchase_without_payout = build(:purchase)
+    assert_nil purchase_without_payout.stripe_payout
+  end
+
+  test '#stripe_payout returns nil if payout is not stripe' do
+    payout = build(:payout)
+    purchase_with_non_stripe_payout = build(:purchase, payout:)
+    assert_nil purchase_with_non_stripe_payout.stripe_payout
+  end
+
+  test '#stripe_payout returns payout if payout is stripe' do
+    stripe_payout = build(:stripe_payout)
+    purchase_with_stripe_payout = build(:purchase, payout: stripe_payout)
+    assert_equal stripe_payout, purchase_with_stripe_payout.stripe_payout
+  end
 end

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -60,4 +60,13 @@ class PurchaseTest < ActiveSupport::TestCase
       create(:purchase)
     end
   end
+
+  test '#platform_fee_in_pence returns the amount we charge the artist' do
+    album = build(:album, price: 10.00)
+    purchase = build(:purchase, album:, price: 15.00)
+    platform_fee_fraction = Rails.configuration.platform_fee_percentage / 100.0
+    expected_fee_in_pence = (1500 * platform_fee_fraction).to_i
+
+    assert_equal expected_fee_in_pence, purchase.platform_fee_in_pence
+  end
 end

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -17,6 +17,11 @@ class PurchaseTest < ActiveSupport::TestCase
     assert purchase.errors[:price].include? 'Price must be more than £5.00'
   end
 
+  test '#price_in_pence' do
+    purchase = build(:purchase, price: 7.00)
+    assert_equal 700, purchase.price_in_pence
+  end
+
   test '#price_excluding_gratuity_in_pence is the album price excluding gratuity' do
     album = build(:album, price: '5.00')
     purchase_without_gratuity = build(:purchase, album:, price: '5.00')

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -69,4 +69,10 @@ class PurchaseTest < ActiveSupport::TestCase
 
     assert_equal expected_fee_in_pence, purchase.platform_fee_in_pence
   end
+
+  test 'can be associated with a payout' do
+    payout = build(:payout)
+    purchase = create(:purchase, payout:)
+    assert_equal payout, purchase.payout
+  end
 end

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -56,4 +56,19 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     @account.assign_attributes(details_submitted: true, charges_enabled: true)
     assert_equal 'charges_enabled', @account.status
   end
+
+  test '#accepts_payments? is false if status is not_started' do
+    @account.assign_attributes(details_submitted: false, charges_enabled: false)
+    assert_not @account.accepts_payments?
+  end
+
+  test '#accepts_payments? is false if status is details_submitted' do
+    @account.assign_attributes(details_submitted: true, charges_enabled: false)
+    assert_not @account.accepts_payments?
+  end
+
+  test '#accepts_payments? is true if status is charges_enabled' do
+    @account.assign_attributes(details_submitted: true, charges_enabled: true)
+    assert @account.accepts_payments?
+  end
 end

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class StripeConnectAccountTest < ActiveSupport::TestCase
+  setup do
+    @account = build(:stripe_connect_account)
+  end
+
+  test 'factory is valid' do
+    assert @account.valid?
+  end
+
+  test 'is invalid without user' do
+    @account.user = nil
+    assert_not @account.valid?
+  end
+
+  test 'is invalid without stripe identifier' do
+    @account.stripe_identifier = nil
+    assert_not @account.valid?
+  end
+
+  test '#details_submitted? is false by default' do
+    assert_not @account.details_submitted?
+  end
+
+  test '#details_submitted? can be set to true' do
+    @account.details_submitted = true
+    assert @account.details_submitted?
+  end
+
+  test '#charges_enabled? is false by default' do
+    assert_not @account.charges_enabled?
+  end
+
+  test '#charges_enabled can be set to true' do
+    @account.charges_enabled = true
+    assert @account.charges_enabled?
+  end
+end

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -38,4 +38,22 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     @account.charges_enabled = true
     assert @account.charges_enabled?
   end
+
+  test "#status returns 'not_started' if #details_submitted? or #charges_enabled? are both false" do
+    @account.assign_attributes(details_submitted: false, charges_enabled: false)
+    assert_equal 'not_started', @account.status
+  end
+
+  test "#status returns 'details_submitted' if #details_submitted? is true & #charges_enabled? is false" do
+    @account.assign_attributes(details_submitted: true, charges_enabled: false)
+    assert_equal 'details_submitted', @account.status
+  end
+
+  test "#status returns 'charges_enabled' if #charges_enabled? is true" do
+    @account.assign_attributes(details_submitted: false, charges_enabled: true)
+    assert_equal 'charges_enabled', @account.status
+
+    @account.assign_attributes(details_submitted: true, charges_enabled: true)
+    assert_equal 'charges_enabled', @account.status
+  end
 end

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -39,6 +39,15 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     assert @account.charges_enabled?
   end
 
+  test '#payouts_enabled? is false by default' do
+    assert_not @account.payouts_enabled?
+  end
+
+  test '#payouts_enabled can be set to true' do
+    @account.payouts_enabled = true
+    assert @account.payouts_enabled?
+  end
+
   test "#status returns 'not_started' if #details_submitted? or #charges_enabled? are both false" do
     @account.assign_attributes(details_submitted: false, charges_enabled: false)
     assert_equal 'not_started', @account.status

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -20,6 +20,11 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     assert_not @account.details_submitted?
   end
 
+  test 'is invalid without country code' do
+    @account.country_code = nil
+    assert_not @account.valid?
+  end
+
   test '#details_submitted? can be set to true' do
     @account.details_submitted = true
     assert @account.details_submitted?

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -23,6 +23,13 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
   test 'is invalid without country code' do
     @account.country_code = nil
     assert_not @account.valid?
+    assert_equal ["can't be blank"], @account.errors[:country_code]
+  end
+
+  test 'is invalid when country code is not GB' do
+    @account.country_code = 'FR'
+    assert_not @account.valid?
+    assert_equal ['is not supported'], @account.errors[:country_code]
   end
 
   test '#details_submitted? can be set to true' do

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -16,11 +16,6 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     assert_not @account.valid?
   end
 
-  test 'is invalid without stripe identifier' do
-    @account.stripe_identifier = nil
-    assert_not @account.valid?
-  end
-
   test '#details_submitted? is false by default' do
     assert_not @account.details_submitted?
   end

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -43,24 +43,6 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     assert @account.payouts_enabled?
   end
 
-  test "#status returns 'not_started' if #details_submitted? or #charges_enabled? are both false" do
-    @account.assign_attributes(details_submitted: false, charges_enabled: false)
-    assert_equal 'not_started', @account.status
-  end
-
-  test "#status returns 'details_submitted' if #details_submitted? is true & #charges_enabled? is false" do
-    @account.assign_attributes(details_submitted: true, charges_enabled: false)
-    assert_equal 'details_submitted', @account.status
-  end
-
-  test "#status returns 'charges_enabled' if #charges_enabled? is true" do
-    @account.assign_attributes(details_submitted: false, charges_enabled: true)
-    assert_equal 'charges_enabled', @account.status
-
-    @account.assign_attributes(details_submitted: true, charges_enabled: true)
-    assert_equal 'charges_enabled', @account.status
-  end
-
   test '#accepts_payments? is false if status is not_started' do
     @account.assign_attributes(details_submitted: false, charges_enabled: false)
     assert_not @account.accepts_payments?

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -3,6 +3,8 @@
 require 'test_helper'
 
 class StripeConnectAccountTest < ActiveSupport::TestCase
+  include ActionMailer::TestHelper
+
   setup do
     @account = build(:stripe_connect_account)
   end
@@ -83,5 +85,41 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     assert @account.details_submitted?
     assert @account.charges_enabled?
     assert @account.payouts_enabled?
+  end
+
+  test '#sync_from! does not email seller when their Stripe account is ready to accept payments or make payments' do
+    stripe_account = Stripe::Account.construct_from(
+      details_submitted: true,
+      charges_enabled: false,
+      payouts_enabled: false
+    )
+
+    assert_no_enqueued_emails do
+      @account.sync_from!(stripe_account)
+    end
+  end
+
+  test '#sync_from! emails seller when their Stripe account is ready to accept payments' do
+    stripe_account = Stripe::Account.construct_from(
+      details_submitted: true,
+      charges_enabled: true,
+      payouts_enabled: false
+    )
+
+    assert_enqueued_email_with StripeConnectAccountMailer, :charges_enabled, params: { account: @account } do
+      @account.sync_from!(stripe_account)
+    end
+  end
+
+  test '#sync_from! emails seller when their Stripe account is ready to make payouts' do
+    stripe_account = Stripe::Account.construct_from(
+      details_submitted: true,
+      charges_enabled: true,
+      payouts_enabled: true
+    )
+
+    assert_enqueued_email_with StripeConnectAccountMailer, :payouts_enabled, params: { account: @account } do
+      @account.sync_from!(stripe_account)
+    end
   end
 end

--- a/test/models/stripe_connect_account_test.rb
+++ b/test/models/stripe_connect_account_test.rb
@@ -80,4 +80,19 @@ class StripeConnectAccountTest < ActiveSupport::TestCase
     @account.assign_attributes(details_submitted: true, charges_enabled: true)
     assert @account.accepts_payments?
   end
+
+  test '#sync_from! copies state attributes from Stripe::Account' do
+    stripe_account = Stripe::Account.construct_from(
+      details_submitted: true,
+      charges_enabled: true,
+      payouts_enabled: true
+    )
+
+    @account.sync_from!(stripe_account)
+
+    @account.reload
+    assert @account.details_submitted?
+    assert @account.charges_enabled?
+    assert @account.payouts_enabled?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -103,4 +103,18 @@ class UserTest < ActiveSupport::TestCase
     user = build(:user, stripe_connect_enabled: true)
     assert user.stripe_connect_enabled?
   end
+
+  test 'can have associated StripeConnectAccount' do
+    user = create(:user)
+    attributes = attributes_for(:stripe_connect_account)
+    user.create_stripe_connect_account!(attributes)
+    assert_equal attributes[:stripe_identifier], user.stripe_connect_account.stripe_identifier
+  end
+
+  test 'destroys associated StripeConnectAccount on destruction' do
+    stripe_connect_account = build(:stripe_connect_account)
+    user = create(:user, stripe_connect_account:)
+    user.destroy!
+    assert_not StripeConnectAccount.exists?(id: stripe_connect_account.id)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -93,4 +93,14 @@ class UserTest < ActiveSupport::TestCase
 
     assert_nil Following.find_by(user:, artist:)
   end
+
+  test '#stripe_connect_enabled? defaults to false' do
+    user = build(:user)
+    assert_not user.stripe_connect_enabled?
+  end
+
+  test '#stripe_connect_enabled? can be set to true' do
+    user = build(:user, stripe_connect_enabled: true)
+    assert user.stripe_connect_enabled?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -117,4 +117,17 @@ class UserTest < ActiveSupport::TestCase
     user.destroy!
     assert_not StripeConnectAccount.exists?(id: stripe_connect_account.id)
   end
+
+  test 'has many payouts' do
+    payouts = build_list(:payout, 2)
+    user = create(:user, payouts:)
+    assert_equal payouts, user.payouts
+  end
+
+  test 'destroys dependent payouts on destruction' do
+    payouts = build_list(:payout, 2)
+    user = create(:user, payouts:)
+    user.destroy!
+    assert payouts.all?(&:destroyed?)
+  end
 end

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -7,30 +7,78 @@ class StripeServiceTest < ActiveSupport::TestCase
 
   def setup
     @purchase = build_stubbed(:purchase)
+    @stripe_connect_account = build(:stripe_connect_account)
   end
 
   test 'creates Stripe checkout session with provided success_url' do
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(success_url: purchase_url(@purchase))
+      has_entry(success_url: purchase_url(@purchase)),
+      anything
     )
 
-    StripeService.new(@purchase).create_checkout_session
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
   end
 
   test 'creates Stripe checkout session with cancel_url' do
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(cancel_url: artist_album_url(@purchase.album.artist, @purchase.album))
+      has_entry(cancel_url: artist_album_url(@purchase.album.artist, @purchase.album)),
+      anything
     )
 
-    StripeService.new(@purchase).create_checkout_session
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
   end
 
   test 'creates Stripe checkout session using album id as client_reference_id' do
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(client_reference_id: @purchase.album.id)
+      has_entry(client_reference_id: @purchase.album.id),
+      anything
     )
 
-    StripeService.new(@purchase).create_checkout_session
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
+  end
+
+  test 'creates Stripe checkout session with Stripe account if it accepts payments' do
+    @stripe_connect_account = create(:stripe_connect_account, charges_enabled: true)
+
+    Stripe::Checkout::Session.expects(:create).with(
+      anything,
+      has_entry(stripe_account: @stripe_connect_account.stripe_identifier)
+    )
+
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
+  end
+
+  test 'creates Stripe checkout session with application fee amount if Stripe account accepts payments' do
+    @stripe_connect_account = create(:stripe_connect_account, charges_enabled: true)
+
+    Stripe::Checkout::Session.expects(:create).with(
+      has_entry(payment_intent_data: { application_fee_amount: @purchase.platform_fee_in_pence }),
+      anything
+    )
+
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
+  end
+
+  test 'creates Stripe checkout session without Stripe account if it does not accept payments' do
+    @stripe_connect_account = create(:stripe_connect_account, charges_enabled: false)
+
+    Stripe::Checkout::Session.expects(:create).with(
+      anything,
+      Not(has_entry(stripe_account: @stripe_connect_account.stripe_identifier))
+    )
+
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
+  end
+
+  test 'creates Stripe checkout session without application fee amount if Stripe account does not accept payments' do
+    @stripe_connect_account = create(:stripe_connect_account, charges_enabled: false)
+
+    Stripe::Checkout::Session.expects(:create).with(
+      Not(has_entry(application_fee_amount: @purchase.platform_fee_in_pence)),
+      anything
+    )
+
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
   end
 
   test 'adds a product line item if the customer pays the suggested price' do
@@ -52,10 +100,11 @@ class StripeServiceTest < ActiveSupport::TestCase
       quantity: 1
     }
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(line_items: [expected_line_item])
+      has_entry(line_items: [expected_line_item]),
+      anything
     )
 
-    StripeService.new(purchase).create_checkout_session
+    StripeService.new(purchase, @stripe_connect_account).create_checkout_session
   end
 
   test 'adds a product line item and a gratuity if the customer pays more than the suggested price' do
@@ -89,10 +138,11 @@ class StripeServiceTest < ActiveSupport::TestCase
       quantity: 1
     }
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(line_items: [expected_purchase_line_item, expected_gratuity_line_item])
+      has_entry(line_items: [expected_purchase_line_item, expected_gratuity_line_item]),
+      anything
     )
 
-    StripeService.new(purchase).create_checkout_session
+    StripeService.new(purchase, @stripe_connect_account).create_checkout_session
   end
 
   test 'returns an ok status if session created successfully' do
@@ -100,7 +150,7 @@ class StripeServiceTest < ActiveSupport::TestCase
       stub(url: 'example.com', id: 'cs_test_foo')
     )
 
-    response = StripeService.new(@purchase).create_checkout_session
+    response = StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
 
     assert_equal 'ok', response.status
     assert_nil response.error
@@ -111,7 +161,7 @@ class StripeServiceTest < ActiveSupport::TestCase
   test 'returns an error status if session creation raises an error' do
     Stripe::Checkout::Session.expects(:create).raises(StandardError, 'message')
 
-    response = StripeService.new(@purchase).create_checkout_session
+    response = StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
 
     assert_equal 'error', response.status
     assert_equal 'message', response.error

--- a/test/services/stripe_service_test.rb
+++ b/test/services/stripe_service_test.rb
@@ -12,8 +12,7 @@ class StripeServiceTest < ActiveSupport::TestCase
 
   test 'creates Stripe checkout session with provided success_url' do
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(success_url: purchase_url(@purchase)),
-      anything
+      has_entry(success_url: purchase_url(@purchase))
     )
 
     StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
@@ -21,8 +20,7 @@ class StripeServiceTest < ActiveSupport::TestCase
 
   test 'creates Stripe checkout session with cancel_url' do
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(cancel_url: artist_album_url(@purchase.album.artist, @purchase.album)),
-      anything
+      has_entry(cancel_url: artist_album_url(@purchase.album.artist, @purchase.album))
     )
 
     StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
@@ -30,8 +28,7 @@ class StripeServiceTest < ActiveSupport::TestCase
 
   test 'creates Stripe checkout session using album id as client_reference_id' do
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(client_reference_id: @purchase.album.id),
-      anything
+      has_entry(client_reference_id: @purchase.album.id)
     )
 
     StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
@@ -41,19 +38,45 @@ class StripeServiceTest < ActiveSupport::TestCase
     @stripe_connect_account = create(:stripe_connect_account, charges_enabled: true)
 
     Stripe::Checkout::Session.expects(:create).with(
-      anything,
-      has_entry(stripe_account: @stripe_connect_account.stripe_identifier)
+      has_entry(
+        payment_intent_data: has_entry(
+          transfer_data: has_entry(
+            destination: @stripe_connect_account.stripe_identifier
+          )
+        )
+      )
     )
 
     StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
   end
 
-  test 'creates Stripe checkout session with application fee amount if Stripe account accepts payments' do
+  test 'creates Stripe checkout session with application fee in metadata if it accepts payments' do
     @stripe_connect_account = create(:stripe_connect_account, charges_enabled: true)
 
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(payment_intent_data: { application_fee_amount: @purchase.platform_fee_in_pence }),
-      anything
+      has_entry(
+        payment_intent_data: has_entry(
+          metadata: has_entry(
+            application_fee_amount: @purchase.platform_fee_in_pence
+          )
+        )
+      )
+    )
+
+    StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
+  end
+
+  test 'creates Stripe checkout session with transfer amount if it accepts payments' do
+    @stripe_connect_account = create(:stripe_connect_account, charges_enabled: true)
+
+    Stripe::Checkout::Session.expects(:create).with(
+      has_entry(
+        payment_intent_data: has_entry(
+          transfer_data: has_entry(
+            amount: @purchase.price_in_pence - @purchase.platform_fee_in_pence
+          )
+        )
+      )
     )
 
     StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
@@ -63,8 +86,13 @@ class StripeServiceTest < ActiveSupport::TestCase
     @stripe_connect_account = create(:stripe_connect_account, charges_enabled: false)
 
     Stripe::Checkout::Session.expects(:create).with(
-      anything,
-      Not(has_entry(stripe_account: @stripe_connect_account.stripe_identifier))
+      Not(
+        has_entry(
+          payment_intent_data: has_entry(
+            transfer_data: { destination: @stripe_connect_account.stripe_identifier }
+          )
+        )
+      )
     )
 
     StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
@@ -74,8 +102,13 @@ class StripeServiceTest < ActiveSupport::TestCase
     @stripe_connect_account = create(:stripe_connect_account, charges_enabled: false)
 
     Stripe::Checkout::Session.expects(:create).with(
-      Not(has_entry(application_fee_amount: @purchase.platform_fee_in_pence)),
-      anything
+      Not(
+        has_entry(
+          payment_intent_data: has_entry(
+            application_fee_amount: @purchase.platform_fee_in_pence
+          )
+        )
+      )
     )
 
     StripeService.new(@purchase, @stripe_connect_account).create_checkout_session
@@ -100,8 +133,7 @@ class StripeServiceTest < ActiveSupport::TestCase
       quantity: 1
     }
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(line_items: [expected_line_item]),
-      anything
+      has_entry(line_items: [expected_line_item])
     )
 
     StripeService.new(purchase, @stripe_connect_account).create_checkout_session
@@ -138,8 +170,7 @@ class StripeServiceTest < ActiveSupport::TestCase
       quantity: 1
     }
     Stripe::Checkout::Session.expects(:create).with(
-      has_entry(line_items: [expected_purchase_line_item, expected_gratuity_line_item]),
-      anything
+      has_entry(line_items: [expected_purchase_line_item, expected_gratuity_line_item])
     )
 
     StripeService.new(purchase, @stripe_connect_account).create_checkout_session

--- a/test/system/collection_test.rb
+++ b/test/system/collection_test.rb
@@ -63,7 +63,8 @@ class CollectionTest < ApplicationSystemTestCase
   def fake_stripe_webhook_event_completed(user)
     checkout_session_id = 'cs_test_foo'
     amount_tax = 0
-    stub_retrieve_stripe_checkout_session(checkout_session_id, user.email, amount_tax)
+    session = stub_retrieve_stripe_checkout_session(checkout_session_id, user.email, amount_tax)
+    stub_retrieve_stripe_payment_intent(session.payment_intent)
     PurchaseCompleteJob.perform_now(checkout_session_id)
   end
 end

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -14,7 +14,7 @@ class StripeConnectTest < ApplicationSystemTestCase
 
       assert_equal account_path, current_path
       assert_text "Account ID: #{stripe_account_id}"
-      assert_text 'Status: Charges enabled'
+      assert_text 'Your Stripe account is connected'
     end
 
     create_published_album

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -35,6 +35,9 @@ class StripeConnectTest < ApplicationSystemTestCase
 
     assert_equal album.price + gratuity, purchase.price
     assert_equal amount_tax, purchase.amount_tax
+
+    assert_equal album.price + gratuity, purchase.stripe_payout.amount
+    assert_equal album.price * platform_fee_fraction, purchase.stripe_payout.platform_fee
   end
 
   private
@@ -64,6 +67,7 @@ class StripeConnectTest < ApplicationSystemTestCase
   def stub_stripe_checkout_flow
     Stripe::Checkout::Session.stubs(:create).returns(stripe_checkout_session)
     Stripe::Checkout::Session.stubs(:retrieve).with(stripe_session_id).returns(stripe_checkout_session)
+    Stripe::PaymentIntent.stubs(:retrieve).with(payment_intent_id).returns(stripe_payment_intent)
     PurchaseCompleteJob.perform_later(stripe_session_id)
   end
 
@@ -76,7 +80,8 @@ class StripeConnectTest < ApplicationSystemTestCase
       },
       total_details: {
         amount_tax:
-      }
+      },
+      payment_intent: payment_intent_id
     )
   end
 
@@ -84,12 +89,41 @@ class StripeConnectTest < ApplicationSystemTestCase
     'cs_test_foo'
   end
 
+  def stripe_payment_intent
+    Stripe::PaymentIntent.construct_from(
+      id: payment_intent_id,
+      metadata: {
+        application_fee_amount:
+      },
+      transfer_data: {
+        destination: stripe_account_id,
+        amount:
+      }
+    )
+  end
+
+  def payment_intent_id
+    'pi_test_foo'
+  end
+
   def tax_percent
     20
   end
 
+  def amount
+    (album.price + gratuity) * 100
+  end
+
   def amount_tax
     album.price * 100 * tax_percent / 100.0
+  end
+
+  def application_fee_amount
+    album.price * 100 * platform_fee_fraction
+  end
+
+  def platform_fee_fraction
+    Rails.configuration.platform_fee_percentage / 100.0
   end
 
   def artist_user

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -57,7 +57,7 @@ class StripeConnectTest < ApplicationSystemTestCase
       Stripe::AccountLink.construct_from(url: success_stripe_connect_account_url(stripe_account_id))
     )
     Stripe::Account.stubs(:retrieve).with(stripe_account_id).returns(
-      Stripe::Account.construct_from(details_submitted: true, charges_enabled: true)
+      Stripe::Account.construct_from(details_submitted: true, charges_enabled: true, payouts_enabled: false)
     )
   end
 

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class StripeConnectTest < ApplicationSystemTestCase
+  test 'enabling Stripe Connect on my account' do
+    stub_stripe_connect_user_flow
+
+    using_session('artist') do
+      log_in_as(artist_user)
+      visit account_path
+
+      click_on 'Connect Stripe'
+
+      assert_equal account_path, current_path
+      assert_text "Account ID: #{stripe_account_id}"
+      assert_text 'Status: Charges enabled'
+    end
+  end
+
+  private
+
+  def stripe_account_id
+    'acct_id'
+  end
+
+  def stub_stripe_connect_user_flow
+    Stripe::Account.stubs(:create).returns(
+      Stripe::Account.construct_from(id: stripe_account_id)
+    )
+    Stripe::AccountLink.stubs(:create).with(
+      has_entry(account: stripe_account_id)
+    ).returns(
+      Stripe::AccountLink.construct_from(url: success_stripe_connect_account_url(stripe_account_id))
+    )
+    Stripe::Account.stubs(:retrieve).with(stripe_account_id).returns(
+      Stripe::Account.construct_from(details_submitted: true, charges_enabled: true)
+    )
+  end
+
+  def artist_user
+    @artist_user ||= create(:user)
+  end
+end

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -93,7 +93,7 @@ class StripeConnectTest < ApplicationSystemTestCase
   end
 
   def artist_user
-    @artist_user ||= create(:user)
+    @artist_user ||= create(:user, stripe_connect_enabled: true)
   end
 
   def artist

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -10,10 +10,15 @@ class StripeConnectTest < ApplicationSystemTestCase
       log_in_as(artist_user)
       visit account_path
 
-      click_on 'Connect Stripe'
+      country_option = '🇬🇧 United Kingdom (GBP)'
+      within(stripe_connect_section) do
+        select country_option, from: 'Country / Region'
+        click_on 'Connect Stripe'
+      end
 
       assert_equal account_path, current_path
       assert_text "Account ID: #{stripe_account_id}"
+      assert_text "Country / Region: #{country_option}"
       assert_text 'Your Stripe account is connected'
     end
 
@@ -44,6 +49,10 @@ class StripeConnectTest < ApplicationSystemTestCase
 
   def gratuity
     3.00
+  end
+
+  def stripe_connect_section
+    find('h2', text: 'Stripe').ancestor('.sidebar-section')
   end
 
   def stripe_account_id

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -3,7 +3,7 @@
 require 'application_system_test_case'
 
 class StripeConnectTest < ApplicationSystemTestCase
-  test 'enabling Stripe Connect on my account' do
+  test 'after enabling Stripe Connect on my account, a customer purchases one of my albums' do
     stub_stripe_connect_user_flow
 
     using_session('artist') do
@@ -16,9 +16,32 @@ class StripeConnectTest < ApplicationSystemTestCase
       assert_text "Account ID: #{stripe_account_id}"
       assert_text 'Status: Charges enabled'
     end
+
+    create_published_album
+    stub_stripe_checkout_flow
+
+    using_session('fan') do
+      visit artist_album_path(album.artist, album)
+      click_on 'Buy'
+      fill_in 'Price', with: album.price + gratuity
+      click_on 'Checkout'
+
+      perform_enqueued_jobs
+
+      visit purchase_path(purchase)
+      assert_text 'Thank you!'
+      assert_text 'Download (mp3v0)'
+    end
+
+    assert_equal album.price + gratuity, purchase.price
+    assert_equal amount_tax, purchase.amount_tax
   end
 
   private
+
+  def gratuity
+    3.00
+  end
 
   def stripe_account_id
     'acct_id'
@@ -38,7 +61,54 @@ class StripeConnectTest < ApplicationSystemTestCase
     )
   end
 
+  def stub_stripe_checkout_flow
+    Stripe::Checkout::Session.stubs(:create).returns(stripe_checkout_session)
+    Stripe::Checkout::Session.stubs(:retrieve).with(stripe_session_id).returns(stripe_checkout_session)
+    PurchaseCompleteJob.perform_later(stripe_session_id)
+  end
+
+  def stripe_checkout_session
+    Stripe::Checkout::Session.construct_from(
+      id: stripe_session_id,
+      url: 'https://stripe.example.com',
+      customer_details: {
+        email: 'fan@example.com'
+      },
+      total_details: {
+        amount_tax:
+      }
+    )
+  end
+
+  def stripe_session_id
+    'cs_test_foo'
+  end
+
+  def tax_percent
+    20
+  end
+
+  def amount_tax
+    album.price * 100 * tax_percent / 100.0
+  end
+
   def artist_user
     @artist_user ||= create(:user)
+  end
+
+  def artist
+    @artist ||= create(:artist, user: artist_user)
+  end
+
+  def album
+    @album ||= create(:published_album, :with_tracks, artist:, price: 7.00)
+  end
+
+  def create_published_album
+    create(:transcode, track: album.tracks.first)
+  end
+
+  def purchase
+    Purchase.last
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,19 +23,38 @@ module ActiveSupport
 
     private
 
-    def stub_retrieve_stripe_checkout_session(checkout_session_id, customer_email, amount_tax)
+    def stub_retrieve_stripe_checkout_session(
+      checkout_session_id, customer_email, amount_tax,
+      payment_intent_id = 'pi_3TBDlLLj0fa0S8sd1X3zPYnl'
+    )
       session = Stripe::Checkout::Session.construct_from(
         {
           id: checkout_session_id,
           customer_details: {
             email: customer_email
           },
+          payment_intent: payment_intent_id,
           total_details: {
             amount_tax:
           }
         }
       )
       Stripe::Checkout::Session.stubs(:retrieve).with(checkout_session_id).returns(session)
+      session
+    end
+
+    def stub_retrieve_stripe_payment_intent(
+      payment_intent_id, amount = nil, application_fee_amount = nil, transfer_data = nil
+    )
+      payment_intent = Stripe::PaymentIntent.construct_from(
+        {
+          id: payment_intent_id,
+          amount:,
+          application_fee_amount:,
+          transfer_data:
+        }
+      )
+      Stripe::PaymentIntent.stubs(:retrieve).with(payment_intent_id).returns(payment_intent)
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -50,7 +50,7 @@ module ActiveSupport
         {
           id: payment_intent_id,
           amount:,
-          application_fee_amount:,
+          metadata: { application_fee_amount: },
           transfer_data:
         }
       )


### PR DESCRIPTION
This allows a user to create a new Stripe account and connect it to their Jam account in order to receive payouts when people buy their music. We're using [Stripe Connect](https://stripe.com/gb/connect) to support this. The feature is currently hidden behind a user-specific feature flag and can be enabled by setting `User#stripe_connect_enabled` to `true`.

When the feature is enabled for a user, a new "Stripe" section will appear on the "My account" page. In this new section, the user will need to select a country and click the "Connect Stripe" button to start the Stripe-hosted onboarding process. We're restricting accounts to the UK only to start with until we've tested the functionality with accounts in different regions in the live/production environment.

Once the user has completed the onboarding process, they will be taken back to the "My account" page. Copy in the "Stripe" section will explain the status of their account - it may take some time for Stripe to enable charges and/or enable payouts on their account, e.g. verification steps that form part of [Stripe's "Know Your Customer" obligations](https://support.stripe.com/questions/know-your-customer-obligations). The seller will receive email notifications from Jam when their connected Stripe account is ready to receive payments and ready to make payouts to their bank account.

When a buyer purchases an album and the seller's connected Stripe account is ready to accept charges, Jam will create [a Destination Charge](https://docs.stripe.com/connect/destination-charges) against Jam's Stripe account and transfer the amount minus the platform fee to the seller's Stripe account. If the seller's Stripe account is not ready to accept charges, Jam will continue to work as it did before, i.e. it will create [a Direct Charge](https://docs.stripe.com/connect/direct-charges) against Jam's Stripe account and payouts will be handled via Wise as before.

If the transfer is made to the seller's Stripe account then the email notifying the seller of the sale will explain that a payment has been made to their Stripe account minus the platform fee. If the seller's Stripe account is not ready to receive charges then the email will explain that they may need to address any outstanding issues.

There should be no significant difference in the experience for buyers.

### Users with an existing Stripe account

I've belatedly [read](https://docs.stripe.com/connect/networked-onboarding) that this Stripe Connect onboarding flow will only work for new Stripe accounts; not for existing Stripe accounts. However, apparently onboarding will be simpler for users who already have a Stripe account, because they should be able to [re-use business information from their existing account](https://docs.stripe.com/connect/networked-onboarding). If it turns out that this is too painful, we might be able to use [the OAuth connection flow](https://docs.stripe.com/connect/oauth-standard-accounts) as an alternative onboarding flow. However, it looks like there are some restrictions on this, e.g. we can't connect to an account that is already connected to another platform.

### Possible further work
* [ ] Prevent sales from sellers who don't have a connected Stripe account that's ready to accept charges and allow them once they have such an account. We might be able to allow sales for £0 (or even a non-zero donation?) in this case. Or maybe allow non-zero sales, but have the proceeds retained by Jam for the benefit of the community.
* [ ] Use `Stripe::Account#requirements` to provide more details on why their Stripe account is not ready.
* [ ] Add a page listing payouts from Jam to the user's Stripe account.
* [ ] Add support for connectig to _existing_ Stripe accounts (see above).
* [ ] Allow connection to Stripe accounts in other countries.
* [ ] Allow user to disconnect (or at least request disconnection of) Stripe account.
* [ ] Address tax reporting obligations for Jam.

### Before deployment
* [ ] Ensure Stripe Connect is configured correctly for the Stripe test environment, e.g. branding.
* [ ] Do some final testing in the Stripe test environment, e.g. check non-UK account is not allowed.
* [ ] Ensure Stripe Connect is configured correctly for the Stripe live environment, e.g. branding.

### After deployment
* [ ] Before testing a transaction in production, consider what will happen when the new Stripe transactions are handled by DoubleAgent.
* [ ] Do some testing in the Stripe live environment, e.g. check onboarding with an existing Stripe account (see above).

Supersedes https://github.com/freerange/jam-coop/pull/348.