### PR TITLE
Avoid GSSAPI-encrypted db connections in dev/test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -25,6 +25,7 @@ default: &default
 development:
   <<: *default
   database: music_coop_development
+  gssencmode: disable
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
@@ -59,6 +60,7 @@ development:
 test:
   <<: *default
   database: music_coop_test
+  gssencmode: disable
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
This seems to have fixed #475 where I was seeing frequent segmentation faults on MacOS. Hopefully it won't have any ill effects on @chrislo or @chrisroos who are using Linux.

Fixes #475.