### PR TITLE
Make default Album#price in factory more realistic

### DIFF
--- a/test/factories/album.rb
+++ b/test/factories/album.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :album do
     artist
     title { 'Whenever You Need Somebody' }
-    price { 700 }
+    price { 7.00 }
     about do
       'Whenever You Need Somebody is the debut studio album by English
        singer Rick Astley, released on 16 November 1987 by RCA


### PR DESCRIPTION
I'm constantly confused by the fact that `Album#price` and `Purchase#price` are both of type `BigDecimal` in pounds and not integers in pence. The database column default is 7.00, i.e. £7.00, which seems realistic. However, for some reason the factory default is 700, i.e. £700, which doesn't seem realistic.

Making this change doesn't seem to break any tests.