### PR TITLE
Fix PurchaseCompleteJob when no payment intent

### DIFF
--- a/app/jobs/purchase_complete_job.rb
+++ b/app/jobs/purchase_complete_job.rb
@@ -9,6 +9,8 @@ class PurchaseCompleteJob < ApplicationJob
     amount_tax = stripe_session.total_details.amount_tax
 
     purchase = Purchase.find_by!(stripe_session_id:)
+    return if purchase.completed?
+
     purchase.update(completed: true, customer_email:, amount_tax:)
     purchase.update(user: User.find_by(email: customer_email)) unless purchase.user
 

--- a/app/jobs/purchase_complete_job.rb
+++ b/app/jobs/purchase_complete_job.rb
@@ -14,16 +14,18 @@ class PurchaseCompleteJob < ApplicationJob
 
     PurchaseMailer.with(purchase:).completed.deliver_later
 
-    payment_intent = Stripe::PaymentIntent.retrieve(stripe_session.payment_intent)
-    if payment_intent.transfer_data.present?
-      payout = purchase.seller.payouts.create!(
-        payout_type: Payout::STRIPE_TYPE,
-        transaction_reference: payment_intent.id,
-        destination_reference: payment_intent.transfer_data.destination,
-        amount_in_pence: payment_intent.transfer_data.amount,
-        platform_fee_in_pence: payment_intent.metadata.application_fee_amount
-      )
-      purchase.update!(payout:)
+    if (payment_intent_id = stripe_session.payment_intent)
+      payment_intent = Stripe::PaymentIntent.retrieve(payment_intent_id)
+      if payment_intent.transfer_data.present?
+        payout = purchase.seller.payouts.create!(
+          payout_type: Payout::STRIPE_TYPE,
+          transaction_reference: payment_intent_id,
+          destination_reference: payment_intent.transfer_data.destination,
+          amount_in_pence: payment_intent.transfer_data.amount,
+          platform_fee_in_pence: payment_intent.metadata.application_fee_amount
+        )
+        purchase.update!(payout:)
+      end
     end
 
     PurchaseMailer.with(purchase:).notify_artist.deliver_later

--- a/test/jobs/purchase_complete_job_test.rb
+++ b/test/jobs/purchase_complete_job_test.rb
@@ -85,6 +85,21 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     assert_equal payout, purchase.reload.payout
   end
 
+  test 'it does not create a payout if there is no payment intent' do
+    stripe_session_id = 'session-id'
+    customer_email = 'email@example.com'
+    amount_tax = 140
+    purchase = create(:purchase, price: 7.00, stripe_session_id:)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax, nil)
+    payment_intent_id = session.payment_intent
+    destination = 'acct_1T7Y4RLr1GW0yJYq'
+    stub_retrieve_stripe_payment_intent(payment_intent_id, 840, 105, { destination:, amount: 700 })
+
+    PurchaseCompleteJob.perform_now(stripe_session_id)
+
+    assert_equal 0, purchase.seller.payouts.count
+  end
+
   test 'it emails the artist' do
     stripe_session_id = 'session-id'
     customer_email = 'email@example.com'

--- a/test/jobs/purchase_complete_job_test.rb
+++ b/test/jobs/purchase_complete_job_test.rb
@@ -9,7 +9,7 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     stripe_session_id = 'session-id'
     customer_email = 'email@example.com'
     amount_tax = 140
-    purchase = create(:purchase, price: 7.00, stripe_session_id:)
+    purchase = create(:purchase, price: 7.00, stripe_session_id:, completed: false)
     session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
     stub_retrieve_stripe_payment_intent(session.payment_intent)
 
@@ -25,7 +25,7 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     user = create(:user)
     customer_email = user.email
     amount_tax = 140
-    purchase = create(:purchase, price: 7.00, stripe_session_id:)
+    purchase = create(:purchase, price: 7.00, stripe_session_id:, completed: false)
     session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
     stub_retrieve_stripe_payment_intent(session.payment_intent)
 
@@ -39,7 +39,7 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     user = create(:user)
     customer_email = 'non-existant-email'
     amount_tax = 140
-    purchase = create(:purchase, price: 7.00, user:, stripe_session_id:)
+    purchase = create(:purchase, price: 7.00, user:, stripe_session_id:, completed: false)
     session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
     stub_retrieve_stripe_payment_intent(session.payment_intent)
 
@@ -52,7 +52,7 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     stripe_session_id = 'session-id'
     customer_email = 'email@example.com'
     amount_tax = 140
-    purchase = create(:purchase, price: 7.00, stripe_session_id:)
+    purchase = create(:purchase, price: 7.00, stripe_session_id:, completed: false)
     session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
     stub_retrieve_stripe_payment_intent(session.payment_intent)
 
@@ -61,11 +61,24 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     end
   end
 
+  test 'it does send any emails if purchase already complete' do
+    stripe_session_id = 'session-id'
+    customer_email = 'email@example.com'
+    amount_tax = 140
+    create(:purchase, price: 7.00, stripe_session_id:, completed: true, customer_email:, amount_tax:)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
+    stub_retrieve_stripe_payment_intent(session.payment_intent)
+
+    assert_no_enqueued_emails do
+      PurchaseCompleteJob.perform_now(stripe_session_id)
+    end
+  end
+
   test 'it creates a payout associated with the seller and the purchase' do
     stripe_session_id = 'session-id'
     customer_email = 'email@example.com'
     amount_tax = 140
-    purchase = create(:purchase, price: 7.00, stripe_session_id:)
+    purchase = create(:purchase, price: 7.00, stripe_session_id:, completed: false)
     session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
     payment_intent_id = session.payment_intent
     destination = 'acct_1T7Y4RLr1GW0yJYq'
@@ -104,7 +117,7 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     stripe_session_id = 'session-id'
     customer_email = 'email@example.com'
     amount_tax = 140
-    purchase = create(:purchase, price: 7.00, stripe_session_id:)
+    purchase = create(:purchase, price: 7.00, stripe_session_id:, completed: false)
     session = stub_retrieve_stripe_checkout_session(stripe_session_id, customer_email, amount_tax)
     stub_retrieve_stripe_payment_intent(session.payment_intent)
 


### PR DESCRIPTION
We saw [this exception][1], because [the checkout session][2] had no payment intent.

[1]: https://app.rollbar.com/a/gofreerange/fix/item/jam/179
[2]: https://dashboard.stripe.com/acct_1O31jELj0fa0S8sd/workbench/events/evt_1TkPAnLj0fa0S8sdulk25lyk