### PR TITLE
SPIKE: "sticky" audio player

### DIFF
--- a/app/javascript/controllers/permanent_player_controller.js
+++ b/app/javascript/controllers/permanent_player_controller.js
@@ -1,0 +1,77 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["audio", "title", "progress"];
+
+  currentIndex = 0;
+
+  load(tracks) {
+    this.tracks = tracks;
+    this.open();
+  }
+
+  open() {
+    this.show();
+    if (this.selectTrack(0)) this.play();
+  }
+
+  close() {
+    this.pause();
+    this.hide();
+  }
+
+  ended() {
+    if (this.selectNextTrack()) this.play();
+  }
+
+  selectNextTrack() {
+    return this.selectTrack(this.currentIndex + 1)
+  }
+
+  selectPreviousTrack() {
+    return this.selectTrack(this.currentIndex - 1)
+  }
+
+  play() {
+    this.audioTarget.play();
+  }
+
+  pause() {
+    this.audioTarget.pause();
+  }
+
+  progress() {
+    let duration = this.audioTarget.duration
+    let currentTime = this.audioTarget.currentTime
+    let progressFraction = currentTime / duration
+    let progressPercent = Math.round(progressFraction * 100)
+
+    if (!Number.isNaN(progressPercent)) {
+      this.progressTarget.textContent = `${progressPercent}%`;
+    }
+  }
+
+  show() {
+    this.element.classList.remove("hidden");
+  }
+
+  hide() {
+    this.element.classList.add("hidden");
+  }
+
+  selectTrack(index) {
+    const track = this.trackWithIndex(index);
+    if (!track) return false;
+
+    this.currentIndex = index;
+    this.audioTarget.src = track.url;
+    this.titleTarget.textContent = track.title;
+    this.progressTarget.textContent = "0%";
+
+    return true;
+  }
+
+  trackWithIndex(index) {
+    return this.tracks?.[index];
+  }
+}

--- a/app/javascript/controllers/play_button_controller.js
+++ b/app/javascript/controllers/play_button_controller.js
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { tracks: Array };
+  static outlets = ["permanent-player"];
+
+  click() {
+    this.permanentPlayerOutlet.load(this.tracksValue);
+  }
+}

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -54,4 +54,11 @@ class Track < ApplicationRecord
   def number
     position.to_s.rjust(2, '0')
   end
+
+  def as_json(*)
+    {
+      title:,
+      url: preview&.file ? Rails.application.routes.url_helpers.cdn_url(preview.file) : nil
+    }
+  end
 end

--- a/app/views/albums/_play_button.html.erb
+++ b/app/views/albums/_play_button.html.erb
@@ -1,0 +1,12 @@
+<%= tag.div(
+  data: {
+    controller: 'play-button',
+    play_button_tracks_value: album.tracks.to_json,
+    play_button_permanent_player_outlet: '#permanent-player'
+  }) do %>
+  <button data-action="play-button#click" class="flex justify-center items-center w-full py-3 bg-slate-600 hover:bg-amber-500 text-white font-medium cursor-pointer">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.348a1.125 1.125 0 010 1.971l-11.54 6.347a1.125 1.125 0 01-1.667-.985V5.653z" />
+    </svg>
+  </button>
+<% end %>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -105,6 +105,8 @@
             <p class="text-xs text-slate-600"><%= number_to_currency(@album.price, unit: '£') %> or more. Digital download. MP3 and FLAC</p>
           <% end %>
         </div>
+
+        <%= render partial: 'play_button', locals: { album: @album } %>
       </div>
     </div>
 

--- a/app/views/layouts/_permanent_player.html.erb
+++ b/app/views/layouts/_permanent_player.html.erb
@@ -1,0 +1,15 @@
+<div id="permanent-player-container" data-turbo-permanent>
+  <div id="permanent-player" data-controller="permanent-player" class="hidden text-slate-800 text-xl">
+    <audio controls data-permanent-player-target="audio" data-action="ended->permanent-player#ended timeupdate->permanent-player#progress" class="hidden"></audio>
+
+    <button data-action="permanent-player#selectPreviousTrack">Previous</button>
+    <button data-action="permanent-player#play">Play</button>
+    <button data-action="permanent-player#pause">Pause</button>
+    <button data-action="permanent-player#selectNextTrack">Next</button>
+
+    <span data-permanent-player-target="title"></span>
+    <span data-permanent-player-target="progress"></span>
+
+    <button data-action="permanent-player#close">Close</button>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,7 @@
 
       <footer class="flex flex-col gap-6 mt-2 mb-4 text-slate-400 text-sm px-2 sm:px-0">
         <div class="flex flex-col gap-3">
+          <%= render partial: 'layouts/permanent_player' %>
           <div>
             <p><%= link_to "News", newsletters_path, class: "underline" %></p>
             <p><%= link_to "About", about_path, class: "underline" %></p>


### PR DESCRIPTION
This adds an extra "play" button below the "Buy" button on the album page. Clicking the new "play" button reveals an unstyled "sticky" player at the bottom of the page with "previous", "play", "pause" & "next" controls and displaying the title of each track and the percentage played. This "sticky" player persists when the user navigates away from the album page until the "close" button is clicked.

The "sticky" player is implemented in `app/views/layouts/_permanent_player.html.erb` and rendered as part of the application layout with the JS behaviour implemented in `app/javascript/controllers/permanent_player_controller.js`.

The new play button is implemented in `app/views/albums/_play_button.html.erb` and rendered as part of the album show page with the JS behaviour implemented in `app/javascript/controllers/play_button_controller.js`. The `click` function in this Stimulus controller calls the `load` function in `app/javascript/controllers/permanent_player_controller.js` using [a Stimulus outlet][1].

TODO:
* Decide whether to keep any of the existing player behaviour on the album page.
* Remove duplication of track data in album show page (JSON & HTML)
* Style the "sticky" player.
* Consider displaying the track duration.
* Decide whether/how to handle tracks with no file/preview.
* Add tests.

Note that I wrote all the above many months after I did the bulk of the implementation, so I may have forgotten stuff!

[1]: https://stimulus.hotwired.dev/reference/outlets