### PR TITLE
Change system test driver from cuprite to playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,14 @@ jobs:
           PGPASSWORD: password
         run: bin/rails test:system
 
-      - name: Upload system test screenshots
+      - name: Upload system test screenshots & traces
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
         with:
           name: System test screenshots
-          path: tmp/screenshots
+          path: |
+            - tmp/screenshots
+            - tmp/playwright-traces
 
   notify:
     name: Notify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,39 @@ jobs:
           PGHOST: localhost
           PGUSER: myapp
           PGPASSWORD: password
-          FERRUM_PROCESS_TIMEOUT: 30
-          FERRUM_DEFAULT_TIMEOUT: 30
-        run: bin/rails test:all
+        run: bin/rails test
+
+      - name: Install Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Identify playwright version
+        id: identify-playwright-version
+        run: echo "playwright_version=$(npm run --silent playwright:version)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache playwright dependencies
+        uses: actions/cache@v5
+        id: cache-playwright-deps
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-v${{ steps.identify-playwright-version.outputs.playwright_version }}
+
+      - name: Install playwright
+        if: ${{ steps.cache-playwright-deps.outputs.cache-hit != 'true' }}
+        run: npx playwright install --with-deps chromium
+
+      - name: Run system tests
+        env:
+          RAILS_ENV: test
+          PGHOST: localhost
+          PGUSER: myapp
+          PGPASSWORD: password
+        run: bin/rails test:system
 
       - name: Upload system test screenshots
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@
 
 /config/credentials/production.key
 /.env
+
+node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ end
 
 group :test do
   gem 'capybara'
+  gem 'capybara-playwright-driver'
   gem 'cuprite'
   gem 'mocha'
   gem 'rubocop-factory_bot'

--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,6 @@ end
 group :test do
   gem 'capybara'
   gem 'capybara-playwright-driver'
-  gem 'cuprite'
   gem 'mocha'
   gem 'rubocop-factory_bot'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,9 +137,6 @@ GEM
     css_parser (1.22.0)
       addressable
     csv (3.3.5)
-    cuprite (0.17)
-      capybara (~> 3.0)
-      ferrum (~> 0.17.0)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -166,12 +163,6 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
-    ferrum (0.17.1)
-      addressable (~> 2.5)
-      base64 (~> 0.2)
-      concurrent-ruby (~> 1.1)
-      webrick (~> 1.7)
-      websocket-driver (~> 0.7)
     ffi (1.17.2)
     ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-darwin)
@@ -479,7 +470,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.1)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -508,7 +498,6 @@ DEPENDENCIES
   capybara
   capybara-playwright-driver
   csv
-  cuprite
   debug
   dotenv-rails
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-playwright-driver (0.5.9)
+      addressable
+      capybara
+      playwright-ruby-client (>= 1.16.0)
     childprocess (5.1.0)
       logger (~> 1.5)
     concurrent-ruby (1.3.7)
@@ -255,6 +259,10 @@ GEM
     matrix (0.4.3)
     meta-tags (2.22.2)
       actionpack (>= 6.0.0, < 8.2)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0414)
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
@@ -302,6 +310,10 @@ GEM
     pg (1.6.2-x86_64-linux)
     pg_query (6.1.0)
       google-protobuf (>= 3.25.3)
+    playwright-ruby-client (1.60.0)
+      base64
+      concurrent-ruby (>= 1.1.6)
+      mime-types (>= 3.0)
     postmark (1.24.0)
       json
     postmark-rails (0.22.1)
@@ -494,6 +506,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.22)
   bootsnap
   capybara
+  capybara-playwright-driver
   csv
   cuprite
   debug

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Linters and test can be run using the default `rake` task.
 
 To run the system tests in a visible/headed browser set the `HEADLESS` environment variable to false. For example: to run all system tests in a visible browser, execute `HEADLESS=false rails test test/system`.
 
+If a system test fails, screenshots will be saved for each session in `tmp/screenshots`. These are also made available as downloadable artifacts in the CI build.
+
 ## Credentials
 
 Environment specific API keys etc. are stored in environment variables. The file `.env.example` should be copied to `.env` so that `Dotenv` can find these in development. You may only need to set these to real values if you need a particular third party service for the code you're working on. For example, Rollbar credentials are only needed if for some reason you need to use rollbar in development.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Linters and test can be run using the default `rake` task.
 
 To run the system tests in a visible/headed browser set the `HEADLESS` environment variable to false. For example: to run all system tests in a visible browser, execute `HEADLESS=false rails test test/system`.
 
-If a system test fails, screenshots will be saved for each session in `tmp/screenshots`. These are also made available as downloadable artifacts in the CI build.
+If a system test fails, screenshots and Playwright traces will be saved for each session in `tmp/screenshots` and `tmp/playwright-traces` respectively. These are also made available as downloadable artifacts in the CI build. You can view a Playwright trace by running `npx playwright show-trace tmp/playwright-traces/<test-name>-<session-name>.zip` or by dropping the zip file into [the online viewer](https://trace.playwright.dev/). 
 
 ## Credentials
 

--- a/app/views/admin/releases/edit.html.erb
+++ b/app/views/admin/releases/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render(SectionComponent.new(title: 'New release')) do %>
+<%= render(SectionComponent.new(title: 'Edit release')) do %>
   <%= render BreadcrumbComponent.new(items: [
       { text: 'My account', link: account_path },
       { text: @label.name, link: edit_admin_label_path(@label) },

--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,12 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
+  puts "\n== Installing JavaScript dependencies =="
+  system! "npm install"
+
+  puts "\n== Installing Playwright dependencies =="
+  system! "npx playwright install --with-deps chromium"
+
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,4 +118,6 @@ Rails.application.routes.draw do
       )
     end
   end
+
+  get '/fake-stripe-checkout', to: proc { [200, {}, []] } if Rails.env.test?
 end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "jam-coop",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "playwright": "^1.61.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "playwright": "^1.61.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "scripts": {
+    "playwright:version": "playwright --version | sed 's/^Version //'"
+  },
   "dependencies": {
     "playwright": "^1.61.1"
   }

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -40,7 +40,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   end
 
   def stub_stripe_checkout_session
-    service = stub(create_checkout_session: stub(success?: true, url: 'https://stripe.example.com', id: 'cs_test_foo'))
+    service = stub(create_checkout_session: stub(success?: true, url: fake_stripe_checkout_path, id: 'cs_test_foo'))
     StripeService.expects(:new).returns(service)
   end
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -2,12 +2,14 @@
 
 require 'test_helper'
 require 'support/screenshot_helper_with_multiple_sessions'
+require 'support/playwright_session_tracing'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ActionMailer::TestHelper
+  include PlaywrightSessionTracing
 
   headless = ActiveRecord::Type::Boolean.new.cast(ENV.fetch('HEADLESS', true))
-  driven_by :playwright, options: { headless: }
+  driven_by :playwright, options: { headless:, tracesDir: PlaywrightSessionTracing::ROOT_PATH }
 
   def setup
     Rails.application.default_url_options = {

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,14 +1,13 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-require 'capybara/cuprite'
 require 'support/screenshot_helper_with_multiple_sessions'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include ActionMailer::TestHelper
 
   headless = ActiveRecord::Type::Boolean.new.cast(ENV.fetch('HEADLESS', true))
-  driven_by :cuprite, options: { headless: }
+  driven_by :playwright, options: { headless: }
 
   def setup
     Rails.application.default_url_options = {

--- a/test/support/playwright_session_tracing.rb
+++ b/test/support/playwright_session_tracing.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module PlaywrightSessionTracing
+  ROOT_PATH = Rails.root.join('tmp/playwright-traces')
+
+  def after_setup
+    super
+
+    start_tracing(session_name: 'default', session: Capybara.current_session)
+  end
+
+  def before_teardown
+    super
+
+    Capybara.send(:session_pool).each do |name, session|
+      session_name = name.split(':')[1].underscore
+      stop_tracing(session_name:, session:, save: failed?)
+    end
+  end
+
+  def using_session(session_name, &block)
+    super do
+      start_tracing(session_name:, session: Capybara.current_session)
+      block.call(session_name)
+    end
+  end
+
+  def start_tracing(session_name:, session:)
+    @session_names ||= Set.new
+    unless @session_names.include?(session_name)
+      session.driver.start_tracing(
+        name: trace_name(session_name),
+        title: trace_name(session_name),
+        screenshots: true,
+        snapshots: true
+      )
+    end
+    @session_names << session_name
+  end
+
+  def stop_tracing(session_name:, session:, save:)
+    if save
+      FileUtils.mkdir_p(ROOT_PATH)
+      path = ROOT_PATH.join("#{trace_name(session_name)}.zip")
+      session.driver.stop_tracing(path: path)
+    else
+      session.driver.stop_tracing
+    end
+  end
+
+  def trace_name(session_name)
+    "#{self.class}-#{name}-#{session_name}"
+  end
+end

--- a/test/system/administering_a_label_test.rb
+++ b/test/system/administering_a_label_test.rb
@@ -11,6 +11,7 @@ class AdministeringALabelTest < ApplicationSystemTestCase
   test 'creating a new label' do
     visit account_path
     click_on 'Add label'
+    assert_text 'New label'
     fill_in 'Name', with: 'Jam Records'
     fill_in 'Location', with: 'London, United Kingdom'
     fill_in 'Description', with: 'Jam Records is the in-house record label for jam.coop'
@@ -25,6 +26,7 @@ class AdministeringALabelTest < ApplicationSystemTestCase
 
     visit account_path
     click_on label.name
+    assert_text 'Edit label'
     fill_in 'Name', with: 'A new name'
 
     click_on 'Save'
@@ -43,6 +45,7 @@ class AdministeringALabelTest < ApplicationSystemTestCase
     fill_in 'Catalogue number', with: 'jam-123'
     click_on 'Save release'
 
+    assert_text 'Edit label'
     within(release_section) do
       assert_text 'album-name'
       assert_text artist.name
@@ -72,6 +75,7 @@ class AdministeringALabelTest < ApplicationSystemTestCase
     select 'other-album', from: 'Album'
     click_on 'Save release'
 
+    assert_text 'Edit label'
     within(release_section) do
       assert_text 'other-album'
       refute_text 'album-name'
@@ -92,11 +96,13 @@ class AdministeringALabelTest < ApplicationSystemTestCase
     end
 
     click_on 'album-name'
+    assert_text 'Edit release'
 
     accept_alert 'Are you sure you want to remove this release?' do
       click_on 'Remove release'
     end
 
+    assert_text 'Edit label'
     within(release_section) do
       refute_text 'album-name'
     end

--- a/test/system/collection_test.rb
+++ b/test/system/collection_test.rb
@@ -15,6 +15,7 @@ class CollectionTest < ApplicationSystemTestCase
     click_on 'Buy'
     fill_in 'Price', with: @album.price
     click_on 'Checkout'
+    assert_current_path fake_stripe_checkout_path
     fake_stripe_webhook_event_completed(@user)
     visit collection_path
     assert_text @album.title
@@ -27,6 +28,7 @@ class CollectionTest < ApplicationSystemTestCase
     click_on 'Buy'
     fill_in 'Price', with: @album.price
     click_on 'Checkout'
+    assert_current_path fake_stripe_checkout_path
     fake_stripe_webhook_event_completed(@user)
 
     log_in_as(@user)
@@ -41,6 +43,7 @@ class CollectionTest < ApplicationSystemTestCase
     click_on 'Buy'
     fill_in 'Price', with: @album.price
     click_on 'Checkout'
+    assert_current_path fake_stripe_checkout_path
     fake_stripe_webhook_event_completed(user)
 
     visit root_path

--- a/test/system/creating_an_album_test.rb
+++ b/test/system/creating_an_album_test.rb
@@ -4,7 +4,6 @@ require 'application_system_test_case'
 
 class CreatingAnAlbumTest < ApplicationSystemTestCase
   setup do
-    skip 'flakey test'
     @artist = create(:artist)
     create(:license)
     @artist_user = create(:user, artists: [@artist])
@@ -25,9 +24,12 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
       fill_in 'Title', with: 'And I Love Her'
       attach_file 'Upload file', Rails.root.join('test/fixtures/files/track.wav')
       click_on 'Save and add another'
+      assert_text 'Track added'
+      assert_text 'New track'
       fill_in 'Title', with: 'Eight days a week'
       attach_file 'Upload file', Rails.root.join('test/fixtures/files/track.wav')
       click_on 'Save'
+      assert_text 'Track added'
       assert_text '1 And I Love Her'
       assert_text '2 Eight days a week'
     end
@@ -64,6 +66,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
                                 Rails.root.join('test/fixtures/files/two.wav'),
                                 Rails.root.join('test/fixtures/files/three.wav')]
     click_on 'Save'
+    assert_text 'Tracks added'
 
     assert_text '1 one'
     assert_text '2 two'
@@ -84,6 +87,7 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
     assert_text "Editing #{album.title}"
     fill_in 'Title', with: 'New Title'
     click_on 'Save'
+    assert_text 'Album was successfully updated'
     assert_text 'New Title'
   end
 
@@ -106,10 +110,12 @@ class CreatingAnAlbumTest < ApplicationSystemTestCase
 
       log_in_as(@artist_user)
       visit edit_artist_path(@artist)
+      assert_text "Editing #{@artist.name}"
       assert_text album.title
       click_on album.title
 
       click_on track.title
+      assert_text 'Edit track'
 
       within(details_section) do
         fill_in 'Title', with: 'Rename the first track'

--- a/test/system/creating_an_artist_test.rb
+++ b/test/system/creating_an_artist_test.rb
@@ -12,6 +12,7 @@ class CreatingAnArtistTest < ApplicationSystemTestCase
   test 'creating an artist' do
     visit account_path
     click_on 'Add artist'
+    assert_text 'New artist'
     fill_in 'Name', with: 'The Beatles'
     fill_in 'Location', with: 'Liverpool'
     fill_in 'Description', with: 'A popular beat combo'

--- a/test/system/identity/password_resets_test.rb
+++ b/test/system/identity/password_resets_test.rb
@@ -12,6 +12,7 @@ module Identity
     test 'sending a password reset email' do
       visit log_in_path
       click_on 'Forgot your password?'
+      assert_selector 'h2', text: 'Forgot your password?'
 
       fill_in 'Email', with: @user.email
       click_on 'Send password reset email'
@@ -21,6 +22,7 @@ module Identity
 
     test 'updating password' do
       visit edit_identity_password_reset_path(sid: @sid)
+      assert_text 'Reset your password'
 
       fill_in 'New password', with: 'Secret6*4*2*'
       fill_in 'Confirm new password', with: 'Secret6*4*2*'

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -83,7 +83,7 @@ class StripeConnectTest < ApplicationSystemTestCase
   def stripe_checkout_session
     Stripe::Checkout::Session.construct_from(
       id: stripe_session_id,
-      url: 'https://stripe.example.com',
+      url: fake_stripe_checkout_path,
       customer_details: {
         email: 'fan@example.com'
       },

--- a/test/system/stripe_connect_test.rb
+++ b/test/system/stripe_connect_test.rb
@@ -30,6 +30,7 @@ class StripeConnectTest < ApplicationSystemTestCase
       click_on 'Buy'
       fill_in 'Price', with: album.price + gratuity
       click_on 'Checkout'
+      assert_current_path fake_stripe_checkout_path
 
       perform_enqueued_jobs
 


### PR DESCRIPTION
This changes the system tests to use the Playwright Capybara driver instead of the Cuprite driver. We're hoping that this will lead to more robust system tests or at least better debugging tools.

I found I had to introduce a fake Stripe checkout page to avoid seeing an error for http://stripe.example.com. We could possibly have used http://example.com, but I think it's better to make the tests more self-contained even at the cost of adding an extra route in the test environment.

I've added a bunch of assertions to make Playwright wait for an interaction to complete (presumably Turbo-related partial page reloads?) - I only added these in places where I saw a test fail. It might be better to go through the system tests more systematically and add assertions in all the places where such interactions happen.

Capybara still saves the screenshots in the same directory, so I think the artefact step in the CI build is still correct. I _think_ [the multi-session screenshot patch](https://github.com/freerange/jam-coop/blob/main/test/support/screenshot_helper_with_multiple_sessions.rb) still works, but I haven't actually looked too hard at it.

Closes https://github.com/freerange/jam-coop/issues/560