### PR TITLE
Add payouts pages

### DIFF
--- a/app/controllers/admin/payouts_controller.rb
+++ b/app/controllers/admin/payouts_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Admin
+  class PayoutsController < AdminController
+    def index
+      @payouts = Payout.stripe.order(:created_at)
+    end
+  end
+end

--- a/app/controllers/payouts_controller.rb
+++ b/app/controllers/payouts_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class PayoutsController < ApplicationController
+  def index
+    @payouts = Current.user.stripe_payouts.order(:created_at)
+    authorize @payouts
+  end
+end

--- a/app/models/payout.rb
+++ b/app/models/payout.rb
@@ -12,6 +12,8 @@ class Payout < ApplicationRecord
   validates :amount_in_pence, presence: true
   validates :platform_fee_in_pence, presence: true
 
+  scope :stripe, -> { where(payout_type: STRIPE_TYPE) }
+
   def stripe?
     payout_type == STRIPE_TYPE
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :followed_artists, through: :followings, source: :artist
   has_many :labels, dependent: :destroy
   has_many :payouts, dependent: :destroy
+  has_many :stripe_payouts, -> { stripe }, class_name: 'Payout', inverse_of: false, dependent: nil
   has_one :payout_detail, dependent: :destroy
   has_one :stripe_connect_account, dependent: :destroy
 

--- a/app/policies/payout_policy.rb
+++ b/app/policies/payout_policy.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PayoutPolicy < ApplicationPolicy
+  def index?
+    user&.stripe_connect_account&.accepts_payments?
+  end
+end

--- a/app/views/admin/payouts/index.html.erb
+++ b/app/views/admin/payouts/index.html.erb
@@ -1,28 +1,7 @@
 <%= render(SectionComponent.new(title: 'Payouts')) do %>
   <div class="flex flex-col divide-y divide-slate-300">
     <% if @payouts.any? %>
-      <table class="table-auto w-full">
-        <thead class="bg-slate-300">
-          <tr>
-            <th class="text-left">Date</th>
-            <th class="text-left">Amount</th>
-            <th class="text-left">Platform fee</th>
-            <th class="text-left">Transaction ref</th>
-            <th class="text-left">Destination ref</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @payouts.each do |payout| %>
-            <tr>
-              <td class="border"><%= payout.created_at.to_date %></td>
-              <td class="border"><%= number_to_currency(payout.amount, unit: "£") %></td>
-              <td class="border"><%= number_to_currency(payout.platform_fee, unit: "£") %></td>
-              <td class="border"><%= payout.transaction_reference %></td>
-              <td class="border"><%= payout.destination_reference %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <%= render partial: 'payouts/table', locals: { payouts: @payouts } %>
     <% else %>
       <p class="text-slate-500 mb-6">
         There aren't any payouts yet.

--- a/app/views/admin/payouts/index.html.erb
+++ b/app/views/admin/payouts/index.html.erb
@@ -1,0 +1,31 @@
+<%= render(SectionComponent.new(title: 'Payouts')) do %>
+  <div class="flex flex-col divide-y divide-slate-300">
+    <% if @payouts.any? %>
+      <table class="table-auto w-full">
+        <thead class="bg-slate-300">
+          <tr>
+            <th class="text-left">Date</th>
+            <th class="text-left">Amount</th>
+            <th class="text-left">Platform fee</th>
+            <th class="text-left">Transaction ref</th>
+            <th class="text-left">Destination ref</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @payouts.each do |payout| %>
+            <tr>
+              <td class="border"><%= payout.created_at.to_date %></td>
+              <td class="border"><%= number_to_currency(payout.amount, unit: "£") %></td>
+              <td class="border"><%= number_to_currency(payout.platform_fee, unit: "£") %></td>
+              <td class="border"><%= payout.transaction_reference %></td>
+              <td class="border"><%= payout.destination_reference %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="text-slate-500 mb-6">
+        There aren't any payouts yet.
+      </p>
+    <% end %>
+  <% end %>

--- a/app/views/application/_avatar_menu.html.erb
+++ b/app/views/application/_avatar_menu.html.erb
@@ -10,6 +10,9 @@
 
     <%= link_to "My account", account_path, class: "block px-4 py-2 text-slate-800 text-sm hover:bg-amber-500 hover:text-white" %>
     <%= link_to 'My feed', activity_path, class: 'block px-4 py-2 text-slate-800 text-sm hover:bg-amber-500 hover:text-white' %>
+    <% if policy(Payout).index? %>
+      <%= link_to 'My payouts', payouts_path, class: 'block px-4 py-2 text-slate-800 text-sm hover:bg-amber-500 hover:text-white' %>
+    <% end %>
     <%= button_to "Log out", Current.session, method: :delete, class: "block w-full flex px-4 pt-2 py-2 text-slate-800 text-sm hover:bg-amber-500 hover:text-white" %>
   </div>
 </div>

--- a/app/views/payouts/_table.html.erb
+++ b/app/views/payouts/_table.html.erb
@@ -1,0 +1,22 @@
+<table class="table-auto w-full">
+  <thead class="bg-slate-300">
+    <tr>
+      <th class="text-left">Date</th>
+      <th class="text-left">Amount</th>
+      <th class="text-left">Platform fee</th>
+      <th class="text-left">Transaction ref</th>
+      <th class="text-left">Destination ref</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% payouts.each do |payout| %>
+      <tr>
+        <td class="border"><%= payout.created_at.to_date %></td>
+        <td class="border"><%= number_to_currency(payout.amount, unit: "£") %></td>
+        <td class="border"><%= number_to_currency(payout.platform_fee, unit: "£") %></td>
+        <td class="border"><%= payout.transaction_reference %></td>
+        <td class="border"><%= payout.destination_reference %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/payouts/index.html.erb
+++ b/app/views/payouts/index.html.erb
@@ -1,28 +1,7 @@
 <%= render(SectionComponent.new(title: 'My payouts')) do %>
   <div class="flex flex-col divide-y divide-slate-300">
     <% if @payouts.any? %>
-      <table class="table-auto w-full">
-        <thead class="bg-slate-300">
-          <tr>
-            <th class="text-left">Date</th>
-            <th class="text-left">Amount</th>
-            <th class="text-left">Platform fee</th>
-            <th class="text-left">Transaction ref</th>
-            <th class="text-left">Destination ref</th>
-          </tr>
-        </thead>
-        <tbody>
-          <% @payouts.each do |payout| %>
-            <tr>
-              <td class="border"><%= payout.created_at.to_date %></td>
-              <td class="border"><%= number_to_currency(payout.amount, unit: "£") %></td>
-              <td class="border"><%= number_to_currency(payout.platform_fee, unit: "£") %></td>
-              <td class="border"><%= payout.transaction_reference %></td>
-              <td class="border"><%= payout.destination_reference %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+      <%= render partial: 'table', locals: { payouts: @payouts } %>
     <% else %>
       <p class="text-slate-500 mb-6">
         You don't have any payouts yet.

--- a/app/views/payouts/index.html.erb
+++ b/app/views/payouts/index.html.erb
@@ -1,0 +1,31 @@
+<%= render(SectionComponent.new(title: 'My payouts')) do %>
+  <div class="flex flex-col divide-y divide-slate-300">
+    <% if @payouts.any? %>
+      <table class="table-auto w-full">
+        <thead class="bg-slate-300">
+          <tr>
+            <th class="text-left">Date</th>
+            <th class="text-left">Amount</th>
+            <th class="text-left">Platform fee</th>
+            <th class="text-left">Transaction ref</th>
+            <th class="text-left">Destination ref</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @payouts.each do |payout| %>
+            <tr>
+              <td class="border"><%= payout.created_at.to_date %></td>
+              <td class="border"><%= number_to_currency(payout.amount, unit: "£") %></td>
+              <td class="border"><%= number_to_currency(payout.platform_fee, unit: "£") %></td>
+              <td class="border"><%= payout.transaction_reference %></td>
+              <td class="border"><%= payout.destination_reference %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="text-slate-500 mb-6">
+        You don't have any payouts yet.
+      </p>
+    <% end %>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
   resource :payout_detail, only: %i[create update]
   resolve('PayoutDetail') { [:payout_detail] }
 
+  resources :payouts, only: %i[index]
+
   namespace :identity do
     resource :email,              only: %i[update]
     resource :email_verification, only: %i[show create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
     mount MissionControl::Jobs::Engine, at: '/jobs'
 
     resources :newsletters, only: %i[index new create edit update]
+    resources :payouts, only: %i[index]
     resources :labels, only: %i[create new edit update] do
       resources :releases, only: %i[new edit create update destroy]
     end

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -5,14 +5,22 @@ Rails.logger.info 'Seeding development environment'
 User.create!(email: 'admin@example.com', password: 'admin-jam-coop', verified: true, admin: true)
 User.create!(email: 'fan@example.com', password: 'fan-jam-coop', verified: true)
 
-6.times do |i|
-  stripe_connect_enabled = i < 3
+users = (0..5).map do |i|
   user = User.create(
     email: "artist-#{i}@example.com",
     password: "artist-#{i}-jam-coop",
     verified: true,
-    stripe_connect_enabled:
+    stripe_connect_enabled: i < 4
   )
+  if i < 3
+    user.create_stripe_connect_account!(
+      details_submitted: i < 3,
+      charges_enabled: i < 2,
+      payouts_enabled: i < 1,
+      country_code: 'GB',
+      stripe_identifier: "stripe-identifier-#{i}"
+    )
+  end
   artist = Artist.create!(
     name: Faker::Music.band,
     location: [Faker::Address.city, Faker::Address.country].join(', '),
@@ -53,6 +61,19 @@ User.create!(email: 'fan@example.com', password: 'fan-jam-coop', verified: true)
 
     album.published!
   end
+  user
+end
+
+3.times do |i|
+  amount_in_pence = 500 + (500 * i)
+  users.first.payouts.create!(
+    payout_type: Payout::STRIPE_TYPE,
+    transaction_reference: "transaction-ref-#{i}",
+    destination_reference: "destination-ref-#{i}",
+    amount_in_pence:,
+    platform_fee_in_pence: amount_in_pence * 0.15,
+    created_at: i.days.ago
+  )
 end
 
 Newsletter.create(title: 'Newsletter #1', body: Faker::Markdown.sandwich(sentences: 6, repeat: 3),

--- a/test/controllers/admin/payouts_controller_test.rb
+++ b/test/controllers/admin/payouts_controller_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Admin
+  class PayoutsControllerTest < ActionDispatch::IntegrationTest
+    test '#index displays table of all Stripe payouts' do
+      create(:stripe_payout, transaction_reference: 'payout-1')
+      create(:stripe_payout, transaction_reference: 'payout-2')
+      create(:payout, transaction_reference: 'non-stripe-payout')
+      admin = create(:user, admin: true)
+      log_in_as(admin)
+
+      get admin_payouts_path
+
+      assert_response :success
+      assert_select 'table tbody' do
+        assert_select 'tr', text: /payout-1/
+        assert_select 'tr', text: /payout-2/
+        assert_select 'tr', text: /non-stripe-payout/, count: 0
+      end
+    end
+
+    test '#index redirects to home page if user is not an admin' do
+      user = create(:user)
+      log_in_as(user)
+
+      get admin_payouts_path
+
+      assert_redirected_to root_path
+      assert_equal 'You are not authorized to perform this action.', flash[:alert]
+    end
+
+    test '#index redirects to login if user is not logged in' do
+      get admin_payouts_path
+
+      assert_redirected_to log_in_path
+    end
+  end
+end

--- a/test/controllers/payouts_controller_test.rb
+++ b/test/controllers/payouts_controller_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PayoutsControllerTest < ActionDispatch::IntegrationTest
+  test '#index displays table of Stripe payouts belonging to user' do
+    stripe_connect_account = create(:stripe_connect_account, charges_enabled: true)
+    payout = create(:stripe_payout, transaction_reference: 'my-payout')
+    create(:stripe_payout, transaction_reference: 'another-payout')
+    create(:payout, transaction_reference: 'non-stripe-payout')
+    user = create(:user, stripe_connect_account:, payouts: [payout])
+    log_in_as(user)
+
+    get payouts_path
+
+    assert_response :success
+    assert_select 'table tbody' do
+      assert_select 'tr', text: /my-payout/
+      assert_select 'tr', text: /another-payout/, count: 0
+      assert_select 'tr', text: /non-stripe-payout/, count: 0
+    end
+  end
+
+  test '#index redirects to login if no user logged in' do
+    get payouts_path
+
+    assert_redirected_to log_in_path
+  end
+end

--- a/test/policies/payout_policy_test.rb
+++ b/test/policies/payout_policy_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PayoutPolicyTest < ActiveSupport::TestCase
+  test '#index? returns true if user has Stripe Connect account accepting payments' do
+    stripe_connect_account = create(:stripe_connect_account, charges_enabled: true)
+    user = create(:user, stripe_connect_account:)
+
+    policy = PayoutPolicy.new(user, Payout.all)
+    assert policy.index?
+  end
+
+  test '#index? returns false if user has Stripe Connect account but not accepting payments' do
+    stripe_connect_account = create(:stripe_connect_account, charges_enabled: false)
+    user = create(:user, stripe_connect_account:)
+
+    policy = PayoutPolicy.new(user, Payout.all)
+    assert_not policy.index?
+  end
+
+  test '#index? returns false if user does not have Stripe Connect account' do
+    user = create(:user)
+
+    policy = PayoutPolicy.new(user, Payout.all)
+    assert_not policy.index?
+  end
+end


### PR DESCRIPTION
* Adds basic "My payouts" page
    * Adds link in avatar menu if user has a connected Stripe account
    * Adds "My payouts" page at `/payouts` path
    * Displays user's Stripe payouts in table form

<img width="2122" height="780" alt="CleanShot 2026-07-12 at 12 21 15@2x" src="https://github.com/user-attachments/assets/44775fa9-6ceb-4423-832b-c7a1e52c94af" />

* Adds basic admin payouts page
    * Adds admin payouts page at `/admin/payouts` path
    * Not currently navigable
    * Displays all Stripe payouts in table form
 
<img width="2112" height="674" alt="CleanShot 2026-07-12 at 12 23 10@2x" src="https://github.com/user-attachments/assets/a7b388f9-292b-4962-acd4-00e7acbb05d4" />

Things I'm not completely sure about:
* The choice of routes - maybe "My payouts" should be under `/account`?
* The use of Pundit - maybe I should use a scope or multiple policies?
* The logic in `db/seeds/development.rb` is now quite complex
* The logic in `PayoutPolicy#index?` - maybe it should allow any user to have access, but prompt them to connect to Stripe if not already connected?
* In general I'm a bit confused about the structure of the routes and how best to use Pundit