### PR TITLE
Stop managing IAM user access key using AWS CDK

### DIFF
--- a/aws-cdk/lib/music-coop-stack.ts
+++ b/aws-cdk/lib/music-coop-stack.ts
@@ -22,11 +22,6 @@ export class MusicCoopStack extends cdk.Stack {
       userName: props.s3Username
     });
 
-    const s3UserNewAccessKey = new iam.CfnAccessKey(this, 's3UserNewCfnAccessKey', {
-      userName: s3User.userName,
-      serial: 1
-    });
-
     const s3Bucket = new s3.Bucket(this, 's3Bucket', {
       bucketName: props.s3BucketName,
       objectOwnership: s3.ObjectOwnership.BUCKET_OWNER_PREFERRED,
@@ -59,14 +54,6 @@ export class MusicCoopStack extends cdk.Stack {
       },
       domainNames: [props.cdnDomainName],
       certificate: props.cdnCertificate
-    });
-
-    new cdk.CfnOutput(this, 's3UserNewAccessKey', {
-      value: s3UserNewAccessKey.ref,
-    });
-
-    new cdk.CfnOutput(this, 's3UserNewSecretAccessKey', {
-      value: s3UserNewAccessKey.attrSecretAccessKey,
     });
 
     new cdk.CfnOutput(this, 'cdnDistributionDomainName', {


### PR DESCRIPTION
This is the user that is used by the Rails app to access the S3 bucket. It's simpler to manage the access key for the user using the AWS web console or the AWS CLI and there's no real benefit to managing it with the AWS CDK.

In preparation for landing this, I've manually created a new access key for both of the following IAM users:

* `arn:aws:iam::746135554472:user/music-coop-s3-user-development`
* `arn:aws:iam::746135554472:user/music-coop-s3-user-production`

I've also changed the `AWS_ACCESS_KEY_ID` & `AWS_SECRET_ACCESS_KEY` env vars for the production app via the Render dashboard.

Anyone using the development stack will need the updated access key credentials which are in 1Password.