### PR TITLE
Authenticate direct uploads

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include RequestContext
   include Pundit::Authorization
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
-  before_action :set_current_request_details
   before_action :authenticate
   after_action :verify_authorized
 
@@ -17,12 +17,6 @@ class ApplicationController < ActionController::Base
 
   def authenticate
     redirect_to main_app.log_in_path unless Current.user
-  end
-
-  def set_current_request_details
-    Current.user_agent = request.user_agent
-    Current.ip_address = request.ip
-    Current.session = Session.find_by(id: cookies.signed[:session_token])
   end
 
   def user_not_authorized

--- a/app/controllers/concerns/request_context.rb
+++ b/app/controllers/concerns/request_context.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RequestContext
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :load_request_context
+  end
+
+  def load_request_context
+    Current.user_agent = request.user_agent
+    Current.ip_address = request.ip
+    Current.session = Session.find_by(id: cookies.signed[:session_token])
+  end
+end

--- a/app/controllers/direct_uploads_controller.rb
+++ b/app/controllers/direct_uploads_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class DirectUploadsController < ActiveStorage::DirectUploadsController
+  include RequestContext
+
+  before_action :authenticate
+
+  private
+
+  def authenticate
+    head :unauthorized unless Current.user
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,8 @@ Rails.application.routes.draw do
 
   get 'up' => 'healthchecks#show'
 
+  post '/rails/active_storage/direct_uploads', to: 'direct_uploads#create', as: :direct_uploads
+
   direct :cdn do |model, options|
     expires_in = options.delete(:expires_in) { ActiveStorage.urls_expire_in }
 

--- a/test/controllers/direct_uploads_controller_test.rb
+++ b/test/controllers/direct_uploads_controller_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DirectUploadsControllerTest < ActionDispatch::IntegrationTest
+  test '#create responds with 200 OK when user is logged in' do
+    user = create(:user)
+    log_in_as(user)
+
+    post direct_uploads_path, params: upload_params
+
+    assert_response :success
+  end
+
+  test '#create responds with 401 Unauthorized when user is not logged in' do
+    post direct_uploads_path, params: upload_params
+
+    assert_response :unauthorized
+  end
+
+  private
+
+  def upload_params
+    {
+      blob: {
+        filename: 'file.wav',
+        content_type: 'audio/x-wav',
+        byte_size: 123,
+        checksum: 'checksum'
+      }
+    }
+  end
+end


### PR DESCRIPTION
By default all ActiveStorage controllers are [publicly accessible][1]. In the case of the `DirectUploadsController` this is currently [being exploited][2] by what we assume are automated scanners looking for vulnerabilities after the [GHSA-xr9x-r78c-5hrm advisory][3] that we patched in [this commit](https://github.com/freerange/jam-coop/commit/21f96a5f03b012a5f7c8286a2765c8d82e7fc2e4).

We don't want unauthenticated users to upload things. This commit routes requests to `/rails/active_storage/direct_uploads` to a custom `DirectUploadsController`. This is achieved by adding a new route with the same
path as the relevant ActiveStorage defined route. The latter is added automatically *after* all the application routes and so our new route will intercept requests to that path first.

Although the `@rails/activestorage` npm package does allow the direct upload URL to be [configured][4] via a `data-direct-upload-url` attribute on the file input element to specify a custom path, this wouldn't buy us much, because there's no easy way to disable the route provided by ActiveStorage. So the unauthenticated route would still be accessible. Much better to override that route with our own custom route which requires authentication.

We've reused the `RequestContext` concern to set `Current.session` which means `Current.user` will be available if the user is logged in.

[1]: https://guides.rubyonrails.org/v8.1/active_storage_overview.html#authenticated-controllers.
[2]: https://app.rollbar.com/a/gofreerange/fix/item/jam/187
[3]: https://github.com/advisories/GHSA-xr9x-r78c-5hrm
[4]: https://guides.rubyonrails.org/v8.1/active_storage_overview.html#usage