### PR TITLE
Content type validation for attachments

### DIFF
--- a/app/form_builders/tailwind_form_builder.rb
+++ b/app/form_builders/tailwind_form_builder.rb
@@ -78,6 +78,10 @@ class TailwindFormBuilder < ActionView::Helpers::FormBuilder
     file_field(method, options.with_defaults(accept: Image.content_types))
   end
 
+  def original_audio_field(method, options = {})
+    file_field(method, options.with_defaults(accept: OriginalAudio.content_types))
+  end
+
   private
 
   def text_like_field(field_method, object_method, options = {})

--- a/app/form_builders/tailwind_form_builder.rb
+++ b/app/form_builders/tailwind_form_builder.rb
@@ -74,6 +74,10 @@ class TailwindFormBuilder < ActionView::Helpers::FormBuilder
     @template.content_tag('div', label + error_label, { class: 'flex flex-col items-start' })
   end
 
+  def image_field(method, options = {})
+    file_field(method, options.with_defaults(accept: Image.content_types))
+  end
+
   private
 
   def text_like_field(field_method, object_method, options = {})

--- a/app/form_builders/tailwind_form_builder.rb
+++ b/app/form_builders/tailwind_form_builder.rb
@@ -75,7 +75,7 @@ class TailwindFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def image_field(method, options = {})
-    file_field(method, options.with_defaults(accept: Image.content_types))
+    file_field(method, options.with_defaults(accept: GenericImage.content_types))
   end
 
   def original_audio_field(method, options = {})

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -4,6 +4,7 @@ class Album < ApplicationRecord
   DATE_OF_INTRODUCTION_OF_AI_POLICY = Date.new(2026, 7, 18)
 
   extend FriendlyId
+  include AttachmentMethods
 
   friendly_id :title, use: :scoped, scope: :artist
 
@@ -24,14 +25,7 @@ class Album < ApplicationRecord
   validates :title, presence: true
   validates :price, presence: true, numericality: true
   validates :number_of_tracks, comparison: { greater_than: 0 }, if: :published?
-  validates(
-    :cover,
-    attached: { message: 'file cannot be missing' },
-    content_type: {
-      in: Image.content_types,
-      message: "must be an image file (#{Image.file_types.join(', ')})"
-    }
-  )
+  validates_image :cover, required: true
   validates :terms_of_use, acceptance: true
   validates :ai_policy, acceptance: true, unless: :created_before_introduction_of_ai_policy?
 

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -28,8 +28,8 @@ class Album < ApplicationRecord
     :cover,
     attached: { message: 'file cannot be missing' },
     content_type: {
-      in: %w[image/jpeg image/png],
-      message: 'must be an image file (jpeg, png)'
+      in: Image.content_types,
+      message: "must be an image file (#{Image.file_types.join(', ')})"
     }
   )
   validates :terms_of_use, acceptance: true

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -2,6 +2,7 @@
 
 class Artist < ApplicationRecord
   extend FriendlyId
+  include AttachmentMethods
 
   friendly_id :slug_candidates, use: :slugged
 
@@ -20,10 +21,7 @@ class Artist < ApplicationRecord
   has_one_attached :profile_picture
 
   validates :name, presence: true
-  validates :profile_picture, content_type: {
-    in: Image.content_types,
-    message: "must be an image file (#{Image.file_types.join(', ')})"
-  }
+  validates_image :profile_picture
 
   scope :listed, -> { where.associated(:albums).where('albums.publication_status': :published).distinct }
   scope :featured, -> { where(featured: true) }

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -20,6 +20,10 @@ class Artist < ApplicationRecord
   has_one_attached :profile_picture
 
   validates :name, presence: true
+  validates :profile_picture, content_type: {
+    in: %w[image/jpeg image/png],
+    message: 'must be an image file (jpeg, png)'
+  }
 
   scope :listed, -> { where.associated(:albums).where('albums.publication_status': :published).distinct }
   scope :featured, -> { where(featured: true) }

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -21,8 +21,8 @@ class Artist < ApplicationRecord
 
   validates :name, presence: true
   validates :profile_picture, content_type: {
-    in: %w[image/jpeg image/png],
-    message: 'must be an image file (jpeg, png)'
+    in: Image.content_types,
+    message: "must be an image file (#{Image.file_types.join(', ')})"
   }
 
   scope :listed, -> { where.associated(:albums).where('albums.publication_status': :published).distinct }

--- a/app/models/concerns/attachment_methods.rb
+++ b/app/models/concerns/attachment_methods.rb
@@ -19,8 +19,8 @@ module AttachmentMethods
     def validates_image(attribute, required: false)
       options = {
         content_type: {
-          in: Image.content_types,
-          message: "must be an image file (#{Image.file_types.join(', ')})"
+          in: GenericImage.content_types,
+          message: "must be an image file (#{GenericImage.file_types.join(', ')})"
         }
       }
       options[:attached] = { message: 'file cannot be missing' } if required

--- a/app/models/concerns/attachment_methods.rb
+++ b/app/models/concerns/attachment_methods.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module AttachmentMethods
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def validates_image(attribute, required: false)
+      options = {
+        content_type: {
+          in: Image.content_types,
+          message: "must be an image file (#{Image.file_types.join(', ')})"
+        }
+      }
+      options[:attached] = { message: 'file cannot be missing' } if required
+
+      validates(attribute, options)
+    end
+  end
+end

--- a/app/models/concerns/attachment_methods.rb
+++ b/app/models/concerns/attachment_methods.rb
@@ -4,6 +4,18 @@ module AttachmentMethods
   extend ActiveSupport::Concern
 
   class_methods do
+    def validates_original_audio(attribute, required: false)
+      options = {
+        content_type: {
+          in: OriginalAudio.content_types,
+          message: "must be an audio file (#{OriginalAudio.file_types.join(', ')})"
+        }
+      }
+      options[:attached] = { message: 'file cannot be missing' } if required
+
+      validates(attribute, options)
+    end
+
     def validates_image(attribute, required: false)
       options = {
         content_type: {

--- a/app/models/generic_image.rb
+++ b/app/models/generic_image.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Image
+module GenericImage
   class << self
     def content_types = %w[image/jpeg image/png]
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Image
+  class << self
+    def content_types = %w[image/jpeg image/png]
+
+    def file_types = %w[jpeg png]
+  end
+end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -2,6 +2,7 @@
 
 class Label < ApplicationRecord
   extend FriendlyId
+  include AttachmentMethods
 
   friendly_id :name, use: :slugged
   belongs_to :user
@@ -10,12 +11,5 @@ class Label < ApplicationRecord
   has_many :albums, through: :releases
 
   validates :name, presence: true
-  validates(
-    :logo,
-    attached: { message: 'file cannot be missing' },
-    content_type: {
-      in: Image.content_types,
-      message: "must be an image file (#{Image.file_types.join(', ')})"
-    }
-  )
+  validates_image :logo, required: true
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -14,8 +14,8 @@ class Label < ApplicationRecord
     :logo,
     attached: { message: 'file cannot be missing' },
     content_type: {
-      in: %w[image/jpeg image/png],
-      message: 'must be an image file (jpeg, png)'
+      in: Image.content_types,
+      message: "must be an image file (#{Image.file_types.join(', ')})"
     }
   )
 end

--- a/app/models/original_audio.rb
+++ b/app/models/original_audio.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module OriginalAudio
+  class << self
+    def content_types = %w[audio/x-wav audio/flac]
+
+    def file_types = %w[WAV FLAC]
+  end
+end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Track < ApplicationRecord
+  include AttachmentMethods
+
   belongs_to :album
   acts_as_list scope: :album
 
@@ -9,9 +11,7 @@ class Track < ApplicationRecord
   delegate :artist, :draft?, to: :album
 
   has_one_attached :original
-  validates :original,
-            attached: { message: 'file cannot be missing' },
-            content_type: { in: OriginalAudio.content_types, message: "must be an audio file (WAV, FLAC)" }
+  validates_original_audio :original, required: true
   validates :title, presence: true
 
   after_create :transcode

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -11,7 +11,7 @@ class Track < ApplicationRecord
   has_one_attached :original
   validates :original,
             attached: { message: 'file cannot be missing' },
-            content_type: { in: %w[audio/x-wav audio/flac], message: 'must be a WAV or FLAC file' }
+            content_type: { in: OriginalAudio.content_types, message: "must be an audio file (WAV, FLAC)" }
   validates :title, presence: true
 
   after_create :transcode

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -11,7 +11,7 @@ class Track < ApplicationRecord
   has_one_attached :original
   validates :original,
             attached: { message: 'file cannot be missing' },
-            content_type: { in: ['audio/x-wav', 'audio/flac'], message: 'must be a WAV or FLAC file' }
+            content_type: { in: %w[audio/x-wav audio/flac], message: 'must be a WAV or FLAC file' }
   validates :title, presence: true
 
   after_create :transcode

--- a/app/views/admin/albums/_form.html.erb
+++ b/app/views/admin/albums/_form.html.erb
@@ -29,7 +29,7 @@
       <%= form.labels :cover, text: "Cover" %>
     <% end %>
 
-    <%= form.file_field :cover, accept: %w[image/jpeg image/png], class: 'block border border-slate-200 mb-3 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+    <%= form.file_field :cover, accept: Image.content_types, class: 'block border border-slate-200 mb-3 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
   <% end %>
 
   <%= render(SidebarSectionComponent.new(title: 'Purchase options')) do %>

--- a/app/views/admin/albums/_form.html.erb
+++ b/app/views/admin/albums/_form.html.erb
@@ -29,7 +29,7 @@
       <%= form.labels :cover, text: "Cover" %>
     <% end %>
 
-    <%= form.file_field :cover, accept: Image.content_types, class: 'block border border-slate-200 mb-3 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+    <%= form.image_field :cover, class: 'block border border-slate-200 mb-3 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
   <% end %>
 
   <%= render(SidebarSectionComponent.new(title: 'Purchase options')) do %>

--- a/app/views/admin/albums/_form.html.erb
+++ b/app/views/admin/albums/_form.html.erb
@@ -29,7 +29,7 @@
       <%= form.labels :cover, text: "Cover" %>
     <% end %>
 
-    <%= form.file_field :cover, accept: 'image/jpeg,image/png', class: 'block border border-slate-200 mb-3 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+    <%= form.file_field :cover, accept: %w[image/jpeg image/png], class: 'block border border-slate-200 mb-3 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
   <% end %>
 
   <%= render(SidebarSectionComponent.new(title: 'Purchase options')) do %>

--- a/app/views/admin/labels/_form.html.erb
+++ b/app/views/admin/labels/_form.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <%= form.label :logo, "Logo" %>
   <% end %>
-  <%= form.file_field :logo, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+  <%= form.file_field :logo, accept: %w[image/jpeg image/png], class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
 
   <div class="flex flex-row justify-end">
     <%= form.submit "Save changes", class: 'mt-3' %>

--- a/app/views/admin/labels/_form.html.erb
+++ b/app/views/admin/labels/_form.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <%= form.label :logo, "Logo" %>
   <% end %>
-  <%= form.file_field :logo, accept: Image.content_types, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+  <%= form.image_field :logo, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
 
   <div class="flex flex-row justify-end">
     <%= form.submit "Save changes", class: 'mt-3' %>

--- a/app/views/admin/labels/_form.html.erb
+++ b/app/views/admin/labels/_form.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <%= form.label :logo, "Logo" %>
   <% end %>
-  <%= form.file_field :logo, accept: %w[image/jpeg image/png], class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+  <%= form.file_field :logo, accept: Image.content_types, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
 
   <div class="flex flex-row justify-end">
     <%= form.submit "Save changes", class: 'mt-3' %>

--- a/app/views/admin/tracks/_form.html.erb
+++ b/app/views/admin/tracks/_form.html.erb
@@ -23,7 +23,7 @@
       <% end %>
 
       <%= form.file_field :original,
-        accept: 'audio/x-wav,audio/flac',
+        accept: %w[audio/x-wav audio/flac],
         direct_upload: true,
         data: { action: 'direct-upload:progress->direct-upload#progress direct-upload:error->direct-upload#error direct-upload:start->direct-upload#fileStart' },
         class: 'block border border-slate-200 mb-2 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>

--- a/app/views/admin/tracks/_form.html.erb
+++ b/app/views/admin/tracks/_form.html.erb
@@ -22,8 +22,7 @@
         <%= form.labels :original, text: "Upload file" %>
       <% end %>
 
-      <%= form.file_field :original,
-        accept: OriginalAudio.content_types,
+      <%= form.original_audio_field :original,
         direct_upload: true,
         data: { action: 'direct-upload:progress->direct-upload#progress direct-upload:error->direct-upload#error direct-upload:start->direct-upload#fileStart' },
         class: 'block border border-slate-200 mb-2 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>

--- a/app/views/admin/tracks/_form.html.erb
+++ b/app/views/admin/tracks/_form.html.erb
@@ -23,7 +23,7 @@
       <% end %>
 
       <%= form.file_field :original,
-        accept: %w[audio/x-wav audio/flac],
+        accept: OriginalAudio.content_types,
         direct_upload: true,
         data: { action: 'direct-upload:progress->direct-upload#progress direct-upload:error->direct-upload#error direct-upload:start->direct-upload#fileStart' },
         class: 'block border border-slate-200 mb-2 file:mr-3 file:px-3 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>

--- a/app/views/admin/tracks/multiple.html.erb
+++ b/app/views/admin/tracks/multiple.html.erb
@@ -20,8 +20,7 @@
         <div data-direct-upload-target="fileInput">
           <%= form.labels :original, text: "Upload files" %>
 
-          <%= form.file_field :original,
-              accept: OriginalAudio.content_types,
+          <%= form.original_audio_field :original,
               direct_upload: true,
               multiple: true,
               data: { action: 'direct-upload:progress->direct-upload#progress direct-upload:error->direct-upload#error direct-upload:start->direct-upload#fileStart', 'direct-upload-target':'fileInput' },

--- a/app/views/admin/tracks/multiple.html.erb
+++ b/app/views/admin/tracks/multiple.html.erb
@@ -21,7 +21,7 @@
           <%= form.labels :original, text: "Upload files" %>
 
           <%= form.file_field :original,
-              accept: 'audio/x-wav,audio/flac',
+              accept: ['audio/x-wav', 'audio/flac'],
               direct_upload: true,
               multiple: true,
               data: { action: 'direct-upload:progress->direct-upload#progress direct-upload:error->direct-upload#error direct-upload:start->direct-upload#fileStart', 'direct-upload-target':'fileInput' },

--- a/app/views/admin/tracks/multiple.html.erb
+++ b/app/views/admin/tracks/multiple.html.erb
@@ -21,7 +21,7 @@
           <%= form.labels :original, text: "Upload files" %>
 
           <%= form.file_field :original,
-              accept: ['audio/x-wav', 'audio/flac'],
+              accept: %w[audio/x-wav audio/flac],
               direct_upload: true,
               multiple: true,
               data: { action: 'direct-upload:progress->direct-upload#progress direct-upload:error->direct-upload#error direct-upload:start->direct-upload#fileStart', 'direct-upload-target':'fileInput' },

--- a/app/views/admin/tracks/multiple.html.erb
+++ b/app/views/admin/tracks/multiple.html.erb
@@ -21,7 +21,7 @@
           <%= form.labels :original, text: "Upload files" %>
 
           <%= form.file_field :original,
-              accept: %w[audio/x-wav audio/flac],
+              accept: OriginalAudio.content_types,
               direct_upload: true,
               multiple: true,
               data: { action: 'direct-upload:progress->direct-upload#progress direct-upload:error->direct-upload#error direct-upload:start->direct-upload#fileStart', 'direct-upload-target':'fileInput' },

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <%= form.label :profile_picture, "Profile picture" %>
   <% end %>
-  <%= form.file_field :profile_picture, accept: Image.content_types, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+  <%= form.image_field :profile_picture, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
 
   <p class="mb-3">By creating an artist profile on jam.coop and
     uploading your music you confirm you have read and agree to our

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <%= form.label :profile_picture, "Profile picture" %>
   <% end %>
-  <%= form.file_field :profile_picture, accept: %w[image/jpeg image/png], class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+  <%= form.file_field :profile_picture, accept: Image.content_types, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
 
   <p class="mb-3">By creating an artist profile on jam.coop and
     uploading your music you confirm you have read and agree to our

--- a/app/views/artists/_form.html.erb
+++ b/app/views/artists/_form.html.erb
@@ -8,7 +8,7 @@
   <% else %>
     <%= form.label :profile_picture, "Profile picture" %>
   <% end %>
-  <%= form.file_field :profile_picture, class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
+  <%= form.file_field :profile_picture, accept: %w[image/jpeg image/png], class: 'mb-3 block border border-slate-200 mb-6 file:mr-3 file:px-5 file:py-3 w-full file:border-0 file:bg-amber-500 hover:file:bg-amber-400 file:text-white file:font-medium' %>
 
   <p class="mb-3">By creating an artist profile on jam.coop and
     uploading your music you confirm you have read and agree to our

--- a/test/models/artist_test.rb
+++ b/test/models/artist_test.rb
@@ -120,4 +120,17 @@ class ArtistTest < ActiveSupport::TestCase
 
     assert_equal [user], artist.reload.followers
   end
+
+  test 'is not valid if profile picture is not an image' do
+    artist = Artist.new
+
+    artist.profile_picture.attach(
+      io: Rails.root.join('test/fixtures/files/dummy.pdf').open,
+      filename: 'dummy.pdf',
+      content_type: 'application/pdf'
+    )
+
+    assert_not artist.valid?
+    assert_includes artist.errors[:profile_picture], 'must be an image file (jpeg, png)'
+  end
 end


### PR DESCRIPTION
We already had content type validation (both client-side and server-side) for some attachments. However, its use was a bit patchy. In particular we had no server-side validation for `Artist#profile_picture`. This extracts applies the same validation across all the relevant attachments and extracts a bunch of duplication.