### PR TITLE
Display link to Stripe payment intent on admin purchases page

### DIFF
--- a/app/helpers/purchases_helper.rb
+++ b/app/helpers/purchases_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PurchasesHelper
+  def link_to_payment_intent(purchase, html_options = nil)
+    id = purchase.payment_intent_id
+    return if id.blank?
+
+    dashboard_origin = 'https://dashboard.stripe.com'
+    env_path = Rails.env.production? ? nil : 'test'
+    payment_path = "payments/#{id}"
+    url = [dashboard_origin, env_path, payment_path].compact.join('/')
+    link_to id, url, html_options
+  end
+end

--- a/app/jobs/purchase_complete_job.rb
+++ b/app/jobs/purchase_complete_job.rb
@@ -28,6 +28,7 @@ class PurchaseCompleteJob < ApplicationJob
         )
         purchase.update!(payout:)
       end
+      purchase.update!(payment_intent_id:)
     end
 
     PurchaseMailer.with(purchase:).notify_artist.deliver_later

--- a/app/views/admin/purchases/index.html.erb
+++ b/app/views/admin/purchases/index.html.erb
@@ -26,7 +26,7 @@
               <td class="border"><%= number_to_currency(purchase.price, unit: "£") %></td>
               <td class="border"><%= number_to_currency(purchase.tax, unit: "£") %></td>
               <td class="border"><%= number_to_currency(purchase.platform_fee, unit: "£") %></td>
-              <td class="border"><%= purchase.payment_intent_id %></td>
+              <td class="border"><%= link_to_payment_intent purchase, class: 'hover:underline' %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/admin/purchases/index.html.erb
+++ b/app/views/admin/purchases/index.html.erb
@@ -12,7 +12,7 @@
             <th class="text-left">Total price</th>
             <th class="text-left">Tax</th>
             <th class="text-left">Platform fee</th>
-            <th class="text-left">Stripe session ID</th>
+            <th class="text-left">Payment intent ID</th>
           </tr>
         </thead>
         <tbody>
@@ -26,7 +26,7 @@
               <td class="border"><%= number_to_currency(purchase.price, unit: "£") %></td>
               <td class="border"><%= number_to_currency(purchase.tax, unit: "£") %></td>
               <td class="border"><%= number_to_currency(purchase.platform_fee, unit: "£") %></td>
-              <td class="border"><%= purchase.stripe_session_id %></td>
+              <td class="border"><%= purchase.payment_intent_id %></td>
             </tr>
           <% end %>
         </tbody>

--- a/db/migrate/20260823090948_add_payment_intent_id_to_purchases.rb
+++ b/db/migrate/20260823090948_add_payment_intent_id_to_purchases.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPaymentIntentIdToPurchases < ActiveRecord::Migration[8.1]
+  def change
+    add_column :purchases, :payment_intent_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_17_155129) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_23_090948) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -168,6 +168,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_17_155129) do
     t.boolean "contact_opt_in", default: false, null: false
     t.datetime "created_at", null: false
     t.string "customer_email"
+    t.string "payment_intent_id"
     t.bigint "payout_id"
     t.decimal "price", precision: 8, scale: 2
     t.datetime "sending_suppressed_at"

--- a/test/jobs/purchase_complete_job_test.rb
+++ b/test/jobs/purchase_complete_job_test.rb
@@ -20,6 +20,18 @@ class PurchaseCompleteJobTest < ActiveJob::TestCase
     assert_equal 140, purchase.reload.amount_tax
   end
 
+  test 'it sets the payment intent ID on the purchase' do
+    stripe_session_id = 'session-id'
+    purchase = create(:purchase, price: 7.00, stripe_session_id:, completed: false)
+    session = stub_retrieve_stripe_checkout_session(stripe_session_id, 'email@example.com', 140)
+    payment_intent_id = session.payment_intent
+    stub_retrieve_stripe_payment_intent(payment_intent_id)
+
+    PurchaseCompleteJob.perform_now(stripe_session_id)
+
+    assert_equal payment_intent_id, purchase.reload.payment_intent_id
+  end
+
   test 'associates the purchase with a user if one exists with this customer_email' do
     stripe_session_id = 'session-id'
     user = create(:user)


### PR DESCRIPTION
This should make it easier to explain transactions in FreeAgent.

I'm planning to backfill the payment intent ID for existing completed purchases, by running the following in the Rails console:

```ruby
Purchase.completed.find_each do |purchase|
  stripe_session = Stripe::Checkout::Session.retrieve(purchase.stripe_session_id)
  purchase.update(payment_intent_id: stripe_session.payment_intent)
end
```

Note that we can't call `Purchase#update!`, because there are 3 invalid completed purchases.