### PR TITLE
Only validate purchase price on creation

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -12,7 +12,7 @@ class Purchase < ApplicationRecord
   has_one :seller, through: :artist, source: :user, class_name: 'User'
 
   validates :price, presence: true, numericality: true
-  validate :price_is_greater_than_album_price, unless: -> { price.blank? }
+  validate :price_is_greater_than_album_price, unless: -> { price.blank? }, on: :create
 
   after_commit :create_purchase_downloads, on: :create
 

--- a/test/models/purchase_test.rb
+++ b/test/models/purchase_test.rb
@@ -9,12 +9,19 @@ class PurchaseTest < ActiveSupport::TestCase
     assert build(:purchase).valid?
   end
 
-  test 'is invalid if price is less than the albums suggested price' do
+  test 'is invalid if price is less than the albums suggested price on creation' do
     album = build(:album, price: '5.00')
     purchase = build(:purchase, album:, price: '3.00')
 
-    assert_not purchase.valid?
+    assert_not purchase.save
     assert purchase.errors[:price].include? 'must be more than £5.00'
+  end
+
+  test 'is valid if price is less than the albums suggested price on update' do
+    album = build(:album, price: '5.00')
+    purchase = create(:purchase, album:, price: '5.00')
+
+    assert purchase.update(price: '3.00')
   end
 
   test '#price_in_pence' do


### PR DESCRIPTION
We've ended up with a few completed purchases (and maybe more incomplete purchases?) in production which have a price less than the album price. Given that there's nothing preventing the artist from increasing the album price over time, it seems more sensible to only validate that the purchase price is greater or equal to the album price on creation of the purchase.

This should mean that all the purchases in production will now be valid.

Closes #663.