### PR TITLE
Fix AI policy validation

### DIFF
--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Album < ApplicationRecord
-  DATE_OF_INTRODUCTION_OF_AI_POLICY = Date.new(2026, 7, 18)
+  AI_POLICY_INTRODUCED_AT = Time.zone.parse('2026-07-18 18:00 +0000')
 
   extend FriendlyId
   include AttachmentMethods
@@ -66,7 +66,7 @@ class Album < ApplicationRecord
   end
 
   def created_before_introduction_of_ai_policy?
-    created_at && created_at < DATE_OF_INTRODUCTION_OF_AI_POLICY
+    created_at && created_at < AI_POLICY_INTRODUCED_AT
   end
 
   private

--- a/test/models/album_test.rb
+++ b/test/models/album_test.rb
@@ -254,8 +254,14 @@ class AlbumTest < ActiveSupport::TestCase
   end
 
   test 'is valid if ai policy is not accepted and created before introduction of policy' do
-    album = create(:album, ai_policy: false, created_at: Album::DATE_OF_INTRODUCTION_OF_AI_POLICY - 1.day)
+    album = create(:album, ai_policy: false, created_at: Album::AI_POLICY_INTRODUCED_AT - 1.minute)
     assert album.valid?
+  end
+
+  test 'is invalid if ai policy is not accepted and created at the time the policy was introduced' do
+    album = build(:album, ai_policy: false, created_at: Album::AI_POLICY_INTRODUCED_AT)
+    album.save
+    assert_not album.valid?
   end
 
   test 'is not valid if cover is not present' do


### PR DESCRIPTION
Previously there were a couple of albums in production which must've been created *just* before the AI policy validation was added. The last of these two was created at 17:58:40 UTC, so I've set the cut-off at 18:00 UTC.

I think comparing a time with a time is clearer that comparing a time with a date and it should mean those two albums will now be valid.

I've made the time zone explicit, because we haven't currently got `config.time_zone` set in `config/application.rb`, so all times are currently UTC. This should be resilient if we later change `config.time_zone` to e.g. "London".

Partially addresses #664.