### PR TITLE
Show featured labels on home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ When a CI build on the `main` branch succeeds the commits are promoted to the `p
 
 ## Downloading production data
 
-This requires you to store the Render database credentials (host, username and password) in environment variables (e.g. in .envrc if using direnv). Get the values from render.com.
+This requires you to store the Render external database URL in an environment variable (e.g. in .envrc if using direnv). Get this from the `jam-db` dashboard on render.com (under the "connect" dropdown).
 
 ```
 # Create a backup of the production database
-PGPASSWORD=${RENDER_DB_PASSWORD} pg_dump -h ${RENDER_DB_HOST} -U ${RENDER_DB_USER} musiccoop > tmp/jam-production-db.sql
+pg_dump --dbname=${RENDER_EXTERNAL_DB_URL} -n public --no-owner > tmp/jam-production-db.sql
 
 # Drop and create the local database
 rails db:drop

--- a/app/avo/resources/label.rb
+++ b/app/avo/resources/label.rb
@@ -25,6 +25,7 @@ module Avo
         field :user, as: :belongs_to
         field :releases, as: :has_many
         field :albums, as: :has_many, through: :releases
+        field :featured, as: :boolean
       end
     end
   end

--- a/app/controllers/labels_controller.rb
+++ b/app/controllers/labels_controller.rb
@@ -2,7 +2,13 @@
 
 class LabelsController < ApplicationController
   before_action :set_label, only: %i[show]
-  skip_before_action :authenticate, only: %i[show]
+  skip_before_action :authenticate, only: %i[index show]
+
+  def index
+    skip_authorization
+
+    @labels = policy_scope(Label).includes(:releases).includes(logo_attachment: :blob).order(created_at: :desc)
+  end
 
   def show
     skip_authorization

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -7,6 +7,7 @@ class PagesController < ApplicationController
   def home
     @featured_artist = Artist.of_the_day
     @best_selling_albums = Album.best_selling.includes(:artist, { cover_attachment: :blob }).limit(4)
+    @featured_labels = Label.featured.limit(4)
   end
 
   def about

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -12,4 +12,6 @@ class Label < ApplicationRecord
 
   validates :name, presence: true
   validates_image :logo, required: true
+
+  scope :with_albums, -> { joins(:albums).distinct }
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -14,4 +14,5 @@ class Label < ApplicationRecord
   validates_image :logo, required: true
 
   scope :with_albums, -> { joins(:albums).distinct }
+  scope :featured, -> { where(featured: true) }
 end

--- a/app/policies/label_policy.rb
+++ b/app/policies/label_policy.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 class LabelPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user.admin?
+        scope.all
+      else
+        scope.with_albums
+      end
+    end
+  end
+
   def new?
     user.admin? || (user.verified? && user.labels_enabled?)
   end

--- a/app/views/labels/index.html.erb
+++ b/app/views/labels/index.html.erb
@@ -1,0 +1,19 @@
+<%
+  set_meta_tags(
+    title: "Labels",
+  )
+%>
+
+<%= render(SectionComponent.new(title: 'Labels')) do %>
+  <%= render(CardGridComponent.new) do %>
+    <% @labels.each do |label| %>
+      <%= link_to(label_path(label)) do %>
+        <%= render(CardComponent.new(
+        title: label.name,
+        subtitle: pluralize(label.releases.size, 'release'),
+        image: ( cdn_url(label.logo.representation(resize_to_limit: [500, 500])) if label.logo.representable? )
+        )) %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -51,7 +51,23 @@
   <% end %>
 
   <%= render(
-  SectionComponent.new(title: 'Best selling')
+  SectionComponent.new(title: 'Labels', link_text: 'More labels', link_path: labels_path)
+) do %>
+    <%= render(CardGridComponent.new) do %>
+      <% @featured_labels.each do |label| %>
+        <%= link_to(label_path(label)) do %>
+          <%= render(CardComponent.new(
+          title: label.name,
+          subtitle: pluralize(label.releases.size, 'release'),
+          image: ( cdn_url(label.logo.representation(resize_to_limit: [500, 500])) if label.logo.representable? )
+        )) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= render(
+  SectionComponent.new(title: 'Best selling albums')
 ) do %>
     <%= render(CardGridComponent.new) do %>
       <% @best_selling_albums.each do |album| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :labels, only: %i[show]
+  resources :labels, only: %i[index show]
   resources :tags, only: %i[show]
 
   resources :email_subscription_changes, only: %i[create]

--- a/db/migrate/20260828143318_add_featured_to_labels.rb
+++ b/db/migrate/20260828143318_add_featured_to_labels.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddFeaturedToLabels < ActiveRecord::Migration[8.1]
+  def change
+    add_column :labels, :featured, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_23_090948) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_28_143318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -102,6 +102,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_23_090948) do
   create_table "labels", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "description"
+    t.boolean "featured", default: false, null: false
     t.string "location"
     t.string "name", null: false
     t.string "slug"

--- a/test/controllers/labels_controller_test.rb
+++ b/test/controllers/labels_controller_test.rb
@@ -39,6 +39,11 @@ class LabelsControllerTestSignedOut < ActionDispatch::IntegrationTest
     create(:release, label: @label, album: @draft_album)
   end
 
+  test '#index' do
+    get labels_path
+    assert_response :success
+  end
+
   test '#show' do
     get label_path(@label)
     assert_response :success

--- a/test/models/label_test.rb
+++ b/test/models/label_test.rb
@@ -30,4 +30,16 @@ class LabelTest < ActiveSupport::TestCase
     assert_not label.valid?
     assert_includes label.errors[:logo], 'must be an image file (jpeg, png)'
   end
+
+  test '.with_albums' do
+    album = create(:album)
+    label_with_albums = create(:label)
+    create(:release, album:, label: label_with_albums)
+    label_without_albums = create(:label)
+
+    scope = Label.with_albums
+
+    assert_includes scope, label_with_albums
+    assert_not_includes scope, label_without_albums
+  end
 end

--- a/test/models/label_test.rb
+++ b/test/models/label_test.rb
@@ -42,4 +42,11 @@ class LabelTest < ActiveSupport::TestCase
     assert_includes scope, label_with_albums
     assert_not_includes scope, label_without_albums
   end
+
+  test 'featured' do
+    create(:label)
+    featured_label = create(:label, featured: true)
+
+    assert_equal [featured_label], Label.featured
+  end
 end


### PR DESCRIPTION
This PR adds a `featured` boolean to `Label` and uses that to populate 4 "featured labels" on the homepage. 

We also want to make it easy for users to find our other labels too, so I've added a labels index page also linked from the homepage. 

After this is deployed I'll manually select 4 labels and modify their `featured` boolean using avo in production.

Closes #677 